### PR TITLE
fix(input): add 'password' declaration for 'input'

### DIFF
--- a/CHANGELOG.en-US.md
+++ b/CHANGELOG.en-US.md
@@ -7,7 +7,7 @@
 - Fix `n-popover` sometimes won't sync position in manual mode.
 - Fix `n-transfer`'s empty icon is no toggling transition.
 - Fix `n-message` API option is not optional.
-- Fix `n-input` misses the `password` type declaration.
+- Fix `n-input` missing the `password` type declaration.
 
 ## 2.11.4
 

--- a/CHANGELOG.en-US.md
+++ b/CHANGELOG.en-US.md
@@ -7,6 +7,7 @@
 - Fix `n-popover` sometimes won't sync position in manual mode.
 - Fix `n-transfer`'s empty icon is no toggling transition.
 - Fix `n-message` API option is not optional.
+- Fix `n-input` misses the `password` type declaration.
 
 ## 2.11.4
 

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -7,6 +7,7 @@
 - 修复 `n-popover` 有时在手动模式不会同步位置
 - 修复 `n-transfer` 的无数据 Icon 没有开关动画
 - 修复 `n-message` API 的 option 不是可选的
+- 修复 `n-input` 缺失`password`的声明
 
 ## 2.11.4
 

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -7,7 +7,7 @@
 - 修复 `n-popover` 有时在手动模式不会同步位置
 - 修复 `n-transfer` 的无数据 Icon 没有开关动画
 - 修复 `n-message` API 的 option 不是可选的
-- 修复 `n-input` 缺失`password`的声明
+- 修复 `n-input` 缺失 `password` 的声明
 
 ## 2.11.4
 

--- a/src/input/src/Input.tsx
+++ b/src/input/src/Input.tsx
@@ -43,7 +43,7 @@ const inputProps = {
     default: undefined
   },
   type: {
-    type: String as PropType<'input' | 'textarea'>,
+    type: String as PropType<'input' | 'textarea' | 'password'>,
     default: 'input'
   },
   placeholder: [Array, String] as PropType<string | [string, string]>,


### PR DESCRIPTION
In the document, the "input" component supports the "password" type, but it is not declared in the code.
在文档里，"input"组件支持"password"类型，但代码里面未声明