### PR TITLE
docs(readme): fix typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,13 +23,13 @@ What's more, they are all treeshakable.
 
 ### Customizable Themes
 
-We provide an advanced type safe theme system that built Uses TypeScript. All you need is to provide a theme overrides object in JS. Then all the stuffs will be done by us.
+We provide an advanced type safe theme system built using TypeScript. All you need is to provide a theme overrides object in JS. Then all the stuff will be done by us.
 
 What's more, no less/sass/css variables, no webpack loaders are required.
 
 ### Uses TypeScript
 
-All the staff in Naive UI is written in TypeScript. It can work with your typescript project seamlessly.
+All the stuff in Naive UI is written in TypeScript. It can work with your typescript project seamlessly.
 
 What's more, you don't need to import any CSS to use the components.
 


### PR DESCRIPTION
<!--
Please add the the changelog to `CHANGELOG.zh-CN.md` & `CHANGELOG.en-US.md` in the PR.
You can only add detailed info in one of them and add a placeholder item in the other (for example `- ***`).
-->
<!--
请在这个 PR 里向 `CHANGELOG.zh-CN.md` 和 `CHANGELOG.en-US.md` 添加这个 PR 的变更记录，
你可以只在其中一个添加详细的信息，然后在另一个文件中留着一个占位的项，例如 `- ***`
-->
This PR just fixes a few typos I noticed in the README. Notably
- `that built Uses TypeScript` :arrow_right: `built using TypeScript`
  - alternative: `that is built using TypeScript`
- `stuffs` :arrow_right: `stuff`: The plural of "stuff" is also "stuff"
- `staff` :arrow_right: `stuff`
- ~~`is wrote` :arrow_right: `is written`~~ **edit**: was already fixed

***

Because the changes in this PR are small, I don't know if the changelog should be updated.