### PR TITLE
Fix crash when load app in head tag

### DIFF
--- a/CHANGELOG.en-US.md
+++ b/CHANGELOG.en-US.md
@@ -4,6 +4,7 @@
 
 ### Fixes
 
+- Fix crash when load app contains `n-button` in head tag #68
 - Fix `n-spin` animation shifts.
 
 ## 2.11.5 (2021-06-10)

--- a/CHANGELOG.en-US.md
+++ b/CHANGELOG.en-US.md
@@ -4,7 +4,7 @@
 
 ### Fixes
 
-- Fix crash when load app contains `n-button` in head tag #68
+- Fix `n-button` causes crash when it's imported in script inside head tag. [#68](https://github.com/TuSimple/naive-ui/pull/68)
 - Fix `n-spin` animation shifts.
 
 ## 2.11.5 (2021-06-10)

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -4,7 +4,7 @@
 
 ### Fixes
 
-- Fix crash when load app contains `n-button` in head tag #68
+- 修正 `n-button` 在 head 内部的 script 被引入造成崩溃 [#68](https://github.com/TuSimple/naive-ui/pull/68)
 - 修正 `n-spin` 动画闪烁
 
 ## 2.11.5 (2021-06-10)

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -4,6 +4,7 @@
 
 ### Fixes
 
+- Fix crash when load app contains `n-button` in head tag #68
 - 修正 `n-spin` 动画闪烁
 
 ## 2.11.5 (2021-06-10)

--- a/src/button/src/styles/button.cssr.ts
+++ b/src/button/src/styles/button.cssr.ts
@@ -154,7 +154,7 @@ export default c([
         animationName: 'button-wave-spread, button-wave-opacity'
       })
     ]),
-    (typeof window !== 'undefined' && 'MozBoxSizing' in document.body.style)
+    (typeof window !== 'undefined' && 'MozBoxSizing' in document.createElement('div').style)
       ? c('&::moz-focus-inner', {
         border: 0
       })


### PR DESCRIPTION
### Environment Info

- Naive UI version: (eg. 2.11.0)
- Browser Info: ( Chome 91)
- System Info: (Windows 10 21H1)

### Steps to reproduce
- Create a static html site
- Build a naive app with a nbutton
- Include app js to head of html file
- App crash, nothing show

### Solution:
- because app js was included to head, so `document.body` is null. Use `document.createElement('div')` instead.