### PR TITLE
fix(cascader): Fix `n-cascader` text blur in win10 Chrome.

### DIFF
--- a/CHANGELOG.en-US.md
+++ b/CHANGELOG.en-US.md
@@ -1,5 +1,13 @@
 # CHANGELOG
 
+## Pending
+
+### Feats
+
+### Fixes
+
+- Fix `n-cascader` text blur in win10 Chrome.
+
 ## 2.11.12 (2020-06-16)
 
 ### Feats

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -1,5 +1,13 @@
 # CHANGELOG
 
+## Pending
+
+### Feats
+
+### Fixes
+
+- 修复 `n-cascader` 在 win10 Chrome 环境下文字模糊的问题
+
 ## 2.11.12 (2020-06-16)
 
 ### Feats

--- a/src/cascader/src/styles/index.cssr.ts
+++ b/src/cascader/src/styles/index.cssr.ts
@@ -50,7 +50,6 @@ export default c([
     cB('cascader-submenu', `
       height: var(--menu-height);
       position: relative;
-      overflow: hidden;
       min-width: 180px;
     `, [
       cB('scrollbar-content', {


### PR DESCRIPTION
Remove the overflow property of the 'n-cascader-submenu' class