### PR TITLE
fix: form-item custom width override

### DIFF
--- a/src/form/src/utils.ts
+++ b/src/form/src/utils.ts
@@ -5,11 +5,9 @@ import type { FormItemSetupProps } from './FormItem'
 import { formInjectionKey } from './interface'
 import type { Size, FormItemRule } from './interface'
 
-export function formItemSize (
-  props: FormItemSetupProps
-): {
-    mergedSize: ComputedRef<Size>
-  } {
+export function formItemSize (props: FormItemSetupProps): {
+  mergedSize: ComputedRef<Size>
+} {
   const NForm = inject(formInjectionKey, null)
   return {
     mergedSize: computed(() => {
@@ -26,16 +24,24 @@ export function formItemMisc (props: FormItemSetupProps) {
   const mergedLabelWidthRef = computed(() => {
     if (mergedLabelPlacementRef.value === 'top') return
     const { labelWidth } = props
-    if (labelWidth !== undefined) return pxfy(labelWidth)
-    if (NForm?.labelWidth !== undefined) return pxfy(NForm.labelWidth)
+
+    if (labelWidth !== undefined) {
+      const isNumber = !isNaN(+labelWidth)
+      return isNumber ? pxfy(labelWidth) : labelWidth
+    }
+
+    if (NForm?.labelWidth !== undefined) {
+      const isNumber = !isNaN(+NForm?.labelWidth)
+      return isNumber ? pxfy(NForm.labelWidth) : NForm.labelWidth
+    }
     return undefined
   })
   const mergedLabelStyleRef = computed(() => {
     return [
-      props.labelStyle,
       {
         width: mergedLabelWidthRef.value
-      }
+      },
+      props.labelStyle
     ]
   })
   const mergedLabelPlacementRef = computed(() => {

--- a/src/form/src/utils.ts
+++ b/src/form/src/utils.ts
@@ -1,9 +1,9 @@
 import { inject, computed, ref, ComputedRef } from 'vue'
 import { get } from 'lodash-es'
-import { pxfy } from 'seemly'
 import type { FormItemSetupProps } from './FormItem'
 import { formInjectionKey } from './interface'
 import type { Size, FormItemRule } from './interface'
+import { formatLength } from '../../_utils'
 
 export function formItemSize (props: FormItemSetupProps): {
   mergedSize: ComputedRef<Size>
@@ -26,13 +26,11 @@ export function formItemMisc (props: FormItemSetupProps) {
     const { labelWidth } = props
 
     if (labelWidth !== undefined) {
-      const isNumber = !isNaN(+labelWidth)
-      return isNumber ? pxfy(labelWidth) : labelWidth
+      return formatLength(labelWidth)
     }
 
     if (NForm?.labelWidth !== undefined) {
-      const isNumber = !isNaN(+NForm?.labelWidth)
-      return isNumber ? pxfy(NForm.labelWidth) : NForm.labelWidth
+      return formatLength(NForm.labelWidth)
     }
     return undefined
   })

--- a/src/transfer/demos/enUS/index.demo-entry.md
+++ b/src/transfer/demos/enUS/index.demo-entry.md
@@ -46,7 +46,7 @@ filterable
 | change | `(Array<string \| number>)` |             |
 
 <!-- ## Notes
-When I heared from my colleague he's going to put more than a thousand items into the transfer, I was astonished. My poor imagination can't come up with a scene that must use a transfer with thousands of items. But I must admit, it's my mind that always not considerate enough.
+When I heard from my colleague he's going to put more than a thousand items into the transfer, I was astonished. My poor imagination can't come up with a scene that must use a transfer with thousands of items. But I must admit, it's my mind that always not considerate enough.
 
 Months earlier, I have built a interesting animation in transfer but it will cause reflow on many DOM elements. At that time, I hadn't think of people would insert so much data in it. Although I never compromise on styles, it's hard to surpass the limit of browser and hardware. It sounds like a kind of philosophy problem to build a car as comfort as a Rolls Royce and as fast as a Ferrari (or Porsche, etc) which is nearly impossible.
 


### PR DESCRIPTION
<!--
!!! Please read the following content if this is your first pull request !!!

1. If you are working on docs, please set `docs` branch as the target branch.
2. If you are working on bug fixes or new features, please set `main` branch as the target branch.

For people who are working on 2, please add changelog to `CHANGELOG.zh-CN.md` & `CHANGELOG.en-US.md` in the PR. You need to add changelog to both files. You can use English in both file. The develop team will translate it later.

About docs & changelog's format and other tips, see in `CONTRIBUTING.md`.
-->
<!--
!!! 如果这是你第一次提交 PR，请阅读下面的内容 !!!

1. 如果你在修改文档，请提交到 `docs` 分支
2. 如果你在修复 Bug 或者开发新的特性，请提交到 `main` 分支

对于进行工作 2 的人，请在 `CHANGELOG.zh-CN.md` & `CHANGELOG.en-US.md` 中添加变更日志，你需要在两个文件中都添加变更日志。你可以只使用中文，开发团队会在之后进行翻译。

关于文档和变更日志的格式以及其他的帮助信息，请参考 `CONTRIBUTING.md`。
-->

修复 FormItem 覆盖自定义宽度，以及 rem 无效的 bug