### PR TITLE
Fix a typo in select.demo.md

### DIFF
--- a/src/menu/demos/enUS/select.demo.md
+++ b/src/menu/demos/enUS/select.demo.md
@@ -1,6 +1,6 @@
 # Select & Routing
 
-Use `@update:value` to listen to the select action of the menu. The firt argument of the callback is the `key` of the selected menu item. The second is the orginal data of the menu item.
+Use `@update:value` to listen to the select action of the menu. The first argument of the callback is the `key` of the selected menu item. The second is the orginal data of the menu item.
 
 Usually you can use vue-router here to accomplish routing. Also, you can render `label` as `<router-link />` or `<a />` to set route.
 


### PR DESCRIPTION
Added the missing "s" in word "firt".

为单词 “firt” 添加缺失的字母 “s”。
