### PR TITLE
fix(input)：修改input输入框设置只读后，清除按钮依然显示的问题

### DIFF
--- a/src/input/src/Input.tsx
+++ b/src/input/src/Input.tsx
@@ -210,6 +210,7 @@ export default defineComponent({
     const showClearButton = computed(() => {
       if (
         props.disabled ||
+        props.readonly ||
         !props.clearable ||
         (!mergedFocusRef.value && !hoverRef.value)
       ) {


### PR DESCRIPTION
input输入框在设置clearable后，会有设置readonly属性，清除按钮依然显示的问题。这样设置了readonly属性，依然可以通过清除按钮清空input输入框内容，不符合一般逻辑。这次PR让showClearButton多判断了是否设置readonly属性
