### PR TITLE
Export light theme object

### DIFF
--- a/CHANGELOG.en-US.md
+++ b/CHANGELOG.en-US.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## Pending
+
+### Feats
+
+- Export `lightTheme` theme object (to match `darkTheme`)
+
 ## 2.15.6 (2021-07-23)
 
 ### Feats

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## Pending
+
+### Feats
+
+- Export `lightTheme` theme object (to match `darkTheme`)
+
 ## 2.15.6 (2021-07-23)
 
 ### Feats

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,8 +10,8 @@ export * from './composables'
 
 // component themes
 export * from './styles'
-// composed global theme, createTheme from component themes util
-export { darkTheme, createTheme } from './themes'
+// composed global themes, createTheme from component themes util
+export { lightTheme, darkTheme, createTheme } from './themes'
 
 export { c, cE, cM, cB, cNotM } from './_utils/cssr'
 

--- a/src/themes/index.ts
+++ b/src/themes/index.ts
@@ -1,2 +1,3 @@
+export { lightTheme } from './light'
 export { darkTheme } from './dark'
 export { createTheme } from './utils'


### PR DESCRIPTION
This matches the existing `darkTheme` object that's already exported.

I need this because I want to pass theme objects around as props,
and I don't want to make that prop nullable for type safety reasons.