### PR TITLE
test(NMenu): fix menu render-icon test cases

### DIFF
--- a/src/menu/demos/enUS/render-label.demo.md
+++ b/src/menu/demos/enUS/render-label.demo.md
@@ -34,7 +34,7 @@ The `render-label`, `render-icon`, `expand-icon` can be used to batch render men
 ```
 
 ```js
-import { h, ref, defineComponent } from 'vue'
+import { h, ref, defineComponent, Comment } from 'vue'
 import { NIcon } from 'naive-ui'
 import { BookmarkOutline, CaretDownOutline } from '@vicons/ionicons5'
 
@@ -120,8 +120,10 @@ export default defineComponent({
         return option.label
       },
       renderMenuIcon (option) {
-        if (option.key === 'beverage') return true
-        if (option.key === 'food') return null // falsy
+        // return comment vnode, render placeholder for indent
+        if (option.key === 'sheep-man') return h(Comment)
+        // return falsy, don't render icon placeholder
+        if (option.key === 'food') return null
         return h(NIcon, null, { default: () => h(BookmarkOutline) })
       },
       expandIcon () {

--- a/src/menu/demos/enUS/render-label.demo.md
+++ b/src/menu/demos/enUS/render-label.demo.md
@@ -34,7 +34,7 @@ The `render-label`, `render-icon`, `expand-icon` can be used to batch render men
 ```
 
 ```js
-import { h, ref, defineComponent, Comment } from 'vue'
+import { h, ref, defineComponent } from 'vue'
 import { NIcon } from 'naive-ui'
 import { BookmarkOutline, CaretDownOutline } from '@vicons/ionicons5'
 
@@ -121,7 +121,7 @@ export default defineComponent({
       },
       renderMenuIcon (option) {
         // return comment vnode, render placeholder for indent
-        if (option.key === 'sheep-man') return h(Comment)
+        if (option.key === 'sheep-man') return h(() => null)
         // return falsy, don't render icon placeholder
         if (option.key === 'food') return null
         return h(NIcon, null, { default: () => h(BookmarkOutline) })

--- a/src/menu/demos/enUS/render-label.demo.md
+++ b/src/menu/demos/enUS/render-label.demo.md
@@ -120,7 +120,7 @@ export default defineComponent({
         return option.label
       },
       renderMenuIcon (option) {
-        // return comment vnode, render placeholder for indent
+        // return render placeholder for indent
         if (option.key === 'sheep-man') return h(() => null)
         // return falsy, don't render icon placeholder
         if (option.key === 'food') return null

--- a/src/menu/demos/zhCN/render-label.demo.md
+++ b/src/menu/demos/zhCN/render-label.demo.md
@@ -34,7 +34,7 @@
 ```
 
 ```js
-import { h, ref, defineComponent } from 'vue'
+import { h, ref, defineComponent, Comment } from 'vue'
 import { NIcon } from 'naive-ui'
 import { BookmarkOutline, CaretDownOutline } from '@vicons/ionicons5'
 
@@ -120,8 +120,10 @@ export default defineComponent({
         return option.label
       },
       renderMenuIcon (option) {
-        if (option.key === 'sheep-man') return true
-        if (option.key === 'food') return null // falsy
+        // 返回 comment VNode 时，渲染图标占位符以保持缩进
+        if (option.key === 'sheep-man') return h(Comment)
+        // 返回 falsy 值，不再渲染图标及占位符
+        if (option.key === 'food') return null
         return h(NIcon, null, { default: () => h(BookmarkOutline) })
       },
       expandIcon () {

--- a/src/menu/demos/zhCN/render-label.demo.md
+++ b/src/menu/demos/zhCN/render-label.demo.md
@@ -34,7 +34,7 @@
 ```
 
 ```js
-import { h, ref, defineComponent, Comment } from 'vue'
+import { h, ref, defineComponent } from 'vue'
 import { NIcon } from 'naive-ui'
 import { BookmarkOutline, CaretDownOutline } from '@vicons/ionicons5'
 
@@ -121,7 +121,7 @@ export default defineComponent({
       },
       renderMenuIcon (option) {
         // 返回 comment VNode 时，渲染图标占位符以保持缩进
-        if (option.key === 'sheep-man') return h(Comment)
+        if (option.key === 'sheep-man') return h(() => null)
         // 返回 falsy 值，不再渲染图标及占位符
         if (option.key === 'food') return null
         return h(NIcon, null, { default: () => h(BookmarkOutline) })

--- a/src/menu/demos/zhCN/render-label.demo.md
+++ b/src/menu/demos/zhCN/render-label.demo.md
@@ -120,7 +120,7 @@ export default defineComponent({
         return option.label
       },
       renderMenuIcon (option) {
-        // 返回 comment VNode 时，渲染图标占位符以保持缩进
+        // 渲染图标占位符以保持缩进
         if (option.key === 'sheep-man') return h(() => null)
         // 返回 falsy 值，不再渲染图标及占位符
         if (option.key === 'food') return null

--- a/src/menu/tests/Menu.spec.ts
+++ b/src/menu/tests/Menu.spec.ts
@@ -1,6 +1,6 @@
 import { mount } from '@vue/test-utils'
 import { HappyOutline } from '@vicons/ionicons5'
-import { h } from 'vue'
+import { h, Comment } from 'vue'
 import { sleep } from 'seemly'
 import { NMenu } from '../index'
 import { NIcon } from '../../icon'
@@ -40,10 +40,6 @@ describe('n-menu', () => {
   it('should work with `render-icon` props', async () => {
     const options = [
       {
-        label: 'yeh',
-        key: 'yeh'
-      },
-      {
         label: 'fantasy',
         key: 'fantasy'
       },
@@ -57,10 +53,12 @@ describe('n-menu', () => {
       }
     ]
     function renderMenuIcon (option: any): any {
-      if (option.key === 'fantasy') return true // render indent
-      if (option.key === 'mojito') return true // render indent
-      if (option.key === 'initialj') return null // don't render
-      return h(NIcon, null, { default: () => h(HappyOutline) }) // render this
+      // return comment vnode, render placeholder for indent
+      if (option.key === 'mojito') return h(Comment)
+      // return falsy, don't render icon placeholder
+      if (option.key === 'initialj') return null
+      // otherwise, render returns vnode
+      return h(NIcon, null, { default: () => h(HappyOutline) })
     }
     const wrapper = mount(NMenu, {
       props: {
@@ -68,7 +66,7 @@ describe('n-menu', () => {
         renderIcon: renderMenuIcon
       }
     })
-    expect(wrapper.findAll('.n-menu-item-content__icon').length).toBe(3)
+    expect(wrapper.findAll('.n-menu-item-content__icon').length).toBe(2)
     expect(wrapper.findAll('.n-icon').length).toBe(1)
   })
 


### PR DESCRIPTION
ref: https://github.com/TuSimple/naive-ui/commit/7cb72375aa1ca5ba68a33140a6f68d9139328a3f

```javascript
function renderMenuIcon (option: any): any {
  // return comment vnode, render placeholder for indent
  if (option.key === 'mojito') return h(() => null)
  // return falsy, don't render icon placeholder
  if (option.key === 'initialj') return null
  // otherwise, render returns vnode
  return h(NIcon, null, { default: () => h(HappyOutline) })
}
```

<!--
!!! Please read the following content if this is your first pull request !!!

1. If you are working on docs, please set `docs` branch as the target branch.
2. If you are working on bug fixes or new features, please set `main` branch as the target branch.

For people who are working on 2, please add changelog to `CHANGELOG.zh-CN.md` & `CHANGELOG.en-US.md` in the PR. You need to add changelog to both files. You can use English in both file. The develop team will translate it later.

About docs & changelog's format and other tips, see in `CONTRIBUTING.md`.
-->
<!--
!!! 如果这是你第一次提交 PR，请阅读下面的内容 !!!

1. 如果你在修改文档，请提交到 `docs` 分支
2. 如果你在修复 Bug 或者开发新的特性，请提交到 `main` 分支

对于进行工作 2 的人，请在 `CHANGELOG.zh-CN.md` & `CHANGELOG.en-US.md` 中添加变更日志，你需要在两个文件中都添加变更日志。你可以只使用中文，开发团队会在之后进行翻译。

关于文档和变更日志的格式以及其他的帮助信息，请参考 `CONTRIBUTING.md`。
-->
