### PR TITLE
fix(slider): fix floating point decimal precision

### DIFF
--- a/CHANGELOG.en-US.md
+++ b/CHANGELOG.en-US.md
@@ -2,9 +2,11 @@
 
 ## Pending
 
+### Feats
+
 ### Fixes
 
-- Fix `n-slider` loss floating point decimal precision
+- Fix `n-slider` loss floating point decimal precision, closes [#751](https://github.com/TuSimple/naive-ui/issues/751).
 
 ## 2.16.0 (2021-08-02)
 

--- a/CHANGELOG.en-US.md
+++ b/CHANGELOG.en-US.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## Pending
+
+### Fixes
+
+- Fix `n-slider` loss floating point decimal precision
+
 ## 2.16.0 (2021-08-02)
 
 ### Breaking Changes

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -2,9 +2,11 @@
 
 ## Pending
 
+### Feats
+
 ### Fixes
 
-- 修复 `n-slider` 丢失浮点数小数精度
+- 修复 `n-slider` 丢失浮点数小数精度，关闭 [#751](https://github.com/TuSimple/naive-ui/issues/751)
 
 ## 2.16.0 (2021-08-02)
 

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## Pending
+
+### Fixes
+
+- 修复 `n-slider` 丢失浮点数小数精度
+
 ## 2.16.0 (2021-08-02)
 
 ### Breaking Changes

--- a/src/slider/src/Slider.tsx
+++ b/src/slider/src/Slider.tsx
@@ -117,7 +117,7 @@ export default defineComponent({
     const precisionRef = computed(() => {
       const precisions = [props.min, props.max, props.step].map((item) => {
         const fraction = String(item).split('.')[1]
-        return decimal ? decimal.length : 0
+        return fraction ? fraction.length : 0
       })
       return Math.max(...precisions)
     })
@@ -466,7 +466,7 @@ export default defineComponent({
       justifiedValue = Math.max(min, justifiedValue)
       justifiedValue = Math.min(max, justifiedValue)
       justifiedValue = Math.round((justifiedValue - min) / step) * step + min
-      justifiedValue = parseFloat(justifiedValue.toFixed(precision.value))
+      justifiedValue = parseFloat(justifiedValue.toFixed(precisionRef.value))
       if (marks) {
         const closestMarkValue = getClosestMarkValue(value)
         if (

--- a/src/slider/src/Slider.tsx
+++ b/src/slider/src/Slider.tsx
@@ -114,6 +114,13 @@ export default defineComponent({
     const railRef = ref<HTMLElement | null>(null)
     const followerRef1 = ref<FollowerInst | null>(null)
     const followerRef2 = ref<FollowerInst | null>(null)
+    const precision = computed(() => {
+      const precisions = [props.min, props.max, props.step].map((item) => {
+        const decimal = String(item).split('.')[1]
+        return decimal ? decimal.length : 0
+      })
+      return Math.max.apply(null, precisions)
+    })
 
     const uncontrolledValueRef = ref(props.defaultValue)
     const controlledValueRef = toRef(props, 'value')
@@ -459,6 +466,7 @@ export default defineComponent({
       justifiedValue = Math.max(min, justifiedValue)
       justifiedValue = Math.min(max, justifiedValue)
       justifiedValue = Math.round((justifiedValue - min) / step) * step + min
+      justifiedValue = parseFloat(justifiedValue.toFixed(precision.value))
       if (marks) {
         const closestMarkValue = getClosestMarkValue(value)
         if (

--- a/src/slider/src/Slider.tsx
+++ b/src/slider/src/Slider.tsx
@@ -116,7 +116,7 @@ export default defineComponent({
     const followerRef2 = ref<FollowerInst | null>(null)
     const precision = computed(() => {
       const precisions = [props.min, props.max, props.step].map((item) => {
-        const decimal = String(item).split('.')[1]
+        const fraction = String(item).split('.')[1]
         return decimal ? decimal.length : 0
       })
       return Math.max(...precisions)

--- a/src/slider/src/Slider.tsx
+++ b/src/slider/src/Slider.tsx
@@ -119,7 +119,7 @@ export default defineComponent({
         const decimal = String(item).split('.')[1]
         return decimal ? decimal.length : 0
       })
-      return Math.max.apply(null, precisions)
+      return Math.max(...precisions)
     })
 
     const uncontrolledValueRef = ref(props.defaultValue)

--- a/src/slider/src/Slider.tsx
+++ b/src/slider/src/Slider.tsx
@@ -114,7 +114,7 @@ export default defineComponent({
     const railRef = ref<HTMLElement | null>(null)
     const followerRef1 = ref<FollowerInst | null>(null)
     const followerRef2 = ref<FollowerInst | null>(null)
-    const precision = computed(() => {
+    const precisionRef = computed(() => {
       const precisions = [props.min, props.max, props.step].map((item) => {
         const fraction = String(item).split('.')[1]
         return decimal ? decimal.length : 0


### PR DESCRIPTION
fix floating point decimal precision
修复 `n-slider` 的浮点数小数精度丢失

issue
close #751