### PR TITLE
fix(data-table): When selectAll is selected, the state display of selectAll should not contain disabled rows

### DIFF
--- a/CHANGELOG.en-US.md
+++ b/CHANGELOG.en-US.md
@@ -12,6 +12,7 @@
 - Fix `n-avatar`'s scale value is incorrect while use v-show, closes [#779](https://github.com/TuSimple/naive-ui/issues/779).
 - Fix `n-menu` show a blue background when click the menu on mobile phone, closes [#799](https://github.com/TuSimple/naive-ui/issues/799).
 - Fix `n-select` filterable select breaks, closes [#510](https://github.com/TuSimple/naive-ui/issues/510).
+- Fix `n-data-table` When selectAll is selected, the state display of selectAll should not contain disabled rows, closes [#778](https://github.com/TuSimple/naive-ui/issues/778).
 
 ## 2.16.1 (2020-08-06)
 

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -12,6 +12,8 @@
 - 修复 `n-avatar` 的缩放在使用 `v-show` 时不正确，关闭 [#779](https://github.com/TuSimple/naive-ui/issues/779)
 - 修复 `n-menu` 在手机端点击菜单的时候出现蓝色背景问题，关闭 [#799](https://github.com/TuSimple/naive-ui/issues/799)
 - 修复 `n-select` 可过滤的选择器失效，关闭 [#510](https://github.com/TuSimple/naive-ui/issues/510)
+- 修复 `n-data-table` 当全选选中时，全选的状态显示不应该包含被禁用的行，关闭 [#778](https://github.com/TuSimple/naive-ui/issues/778)
+
 
 ## 2.16.1 (2020-08-06)
 

--- a/src/data-table/src/use-check.ts
+++ b/src/data-table/src/use-check.ts
@@ -47,24 +47,33 @@ export function useCheck (
   const countOfCurrentPageCheckedRowsRef = computed(() => {
     const { value: mergedCheckedRowKeySet } = mergedCheckedRowKeySetRef
     return paginatedDataRef.value.reduce((total, tmNode) => {
-      const { key } = tmNode
-      return total + (mergedCheckedRowKeySet.has(key) ? 1 : 0)
+      const { key, disabled } = tmNode
+      return total + (disabled ? 0 : mergedCheckedRowKeySet.has(key) ? 1 : 0)
     }, 0)
   })
+  const countOfCurrentPageDisabledRowsRef = computed(() => {
+    const { length } = paginatedDataRef.value.filter((item) => item.disabled)
+    return length
+  })
   const someRowsCheckedRef = computed(() => {
+    const { length } = paginatedDataRef.value
     const { value: mergedInderminateRowKeySet } = mergedInderminateRowKeySetRef
-    const { length } = paginatedDataRef.value.filter((item) => !item.disabled)
     return (
       (countOfCurrentPageCheckedRowsRef.value > 0 &&
-        countOfCurrentPageCheckedRowsRef.value < length) ||
+        countOfCurrentPageCheckedRowsRef.value <
+          length - countOfCurrentPageDisabledRowsRef.value) ||
       paginatedDataRef.value.some((rowData) =>
         mergedInderminateRowKeySet.has(rowData.key)
       )
     )
   })
   const allRowsCheckedRef = computed(() => {
-    const { length } = paginatedDataRef.value.filter((item) => !item.disabled)
-    return length !== 0 && countOfCurrentPageCheckedRowsRef.value === length
+    const { length } = paginatedDataRef.value
+    return (
+      countOfCurrentPageCheckedRowsRef.value !== 0 &&
+      countOfCurrentPageCheckedRowsRef.value ===
+        length - countOfCurrentPageDisabledRowsRef.value
+    )
   })
   const headerCheckboxDisabledRef = computed(() => {
     return paginatedDataRef.value.length === 0

--- a/src/data-table/src/use-check.ts
+++ b/src/data-table/src/use-check.ts
@@ -53,17 +53,17 @@ export function useCheck (
   })
   const someRowsCheckedRef = computed(() => {
     const { value: mergedInderminateRowKeySet } = mergedInderminateRowKeySetRef
+    const { length } = paginatedDataRef.value.filter((item) => !item.disabled)
     return (
       (countOfCurrentPageCheckedRowsRef.value > 0 &&
-        countOfCurrentPageCheckedRowsRef.value <
-          paginatedDataRef.value.length) ||
+        countOfCurrentPageCheckedRowsRef.value < length) ||
       paginatedDataRef.value.some((rowData) =>
         mergedInderminateRowKeySet.has(rowData.key)
       )
     )
   })
   const allRowsCheckedRef = computed(() => {
-    const { length } = paginatedDataRef.value
+    const { length } = paginatedDataRef.value.filter((item) => !item.disabled)
     return length !== 0 && countOfCurrentPageCheckedRowsRef.value === length
   })
   const headerCheckboxDisabledRef = computed(() => {

--- a/src/data-table/src/use-check.ts
+++ b/src/data-table/src/use-check.ts
@@ -48,12 +48,11 @@ export function useCheck (
     const { value: mergedCheckedRowKeySet } = mergedCheckedRowKeySetRef
     return paginatedDataRef.value.reduce((total, tmNode) => {
       const { key, disabled } = tmNode
-      return total + (disabled ? 0 : mergedCheckedRowKeySet.has(key) ? 1 : 0)
+      return total + (!disabled && mergedCheckedRowKeySet.has(key) ? 1 : 0)
     }, 0)
   })
   const countOfCurrentPageDisabledRowsRef = computed(() => {
-    const { length } = paginatedDataRef.value.filter((item) => item.disabled)
-    return length
+    return paginatedDataRef.value.filter((item) => item.disabled).length
   })
   const someRowsCheckedRef = computed(() => {
     const { length } = paginatedDataRef.value


### PR DESCRIPTION
fix [#778](https://github.com/TuSimple/naive-ui/issues/778).