### PR TITLE
feat(message): Add `container-style` prop to `n-message-provider`

### DIFF
--- a/CHANGELOG.en-US.md
+++ b/CHANGELOG.en-US.md
@@ -2,6 +2,10 @@
 
 ## Pending
 
+### Feats
+
+- `n-message-provider` add `container-style` prop
+
 ### Fixes
 
 - Fix `n-rate` half star overlays star background in dark mode.

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -1,7 +1,10 @@
 # CHANGELOG
 
-
 ## Pending
+
+### Feats
+
+- `n-message-provider` add `container-style` prop
 
 ### Fixes
 

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -4,7 +4,7 @@
 
 ### Feats
 
-- `n-message-provider` add `container-style` prop
+- `n-message-provider` 新增 `container-style` 属性
 
 ### Fixes
 

--- a/src/message/src/MessageProvider.tsx
+++ b/src/message/src/MessageProvider.tsx
@@ -73,10 +73,7 @@ const messageProviderProps = {
   },
   max: Number,
   closable: Boolean,
-  containerStyle: {
-    type: [String, Object] as PropType<string | CSSProperties>,
-    default: ''
-  }
+  containerStyle: [String, Object] as PropType<string | CSSProperties>
 }
 
 export type MessageProviderProps = ExtractPublicPropTypes<

--- a/src/message/src/MessageProvider.tsx
+++ b/src/message/src/MessageProvider.tsx
@@ -11,7 +11,8 @@ import {
   ExtractPropTypes,
   renderSlot,
   Ref,
-  PropType
+  PropType,
+  CSSProperties
 } from 'vue'
 import { createId } from 'seemly'
 import { ExtractPublicPropTypes, omit } from '../../_utils'
@@ -71,7 +72,11 @@ const messageProviderProps = {
     default: 3000
   },
   max: Number,
-  closable: Boolean
+  closable: Boolean,
+  containerStyle: {
+    type: [String, Object] as PropType<string | CSSProperties>,
+    default: ''
+  }
 }
 
 export type MessageProviderProps = ExtractPublicPropTypes<
@@ -164,6 +169,7 @@ export default defineComponent({
             <div
               class={`${this.mergedClsPrefix}-message-container`}
               key="message-container"
+              style={this.containerStyle}
             >
               {this.messageList.map((message) => {
                 return (

--- a/src/message/tests/Message.spec.tsx
+++ b/src/message/tests/Message.spec.tsx
@@ -111,4 +111,31 @@ describe('message-provider', () => {
       done()
     })
   })
+
+  it('props.container-style', (done) => {
+    const Test = defineComponent({
+      setup () {
+        const message = useMessage()
+        message.info('string')
+      },
+      render () {
+        return null
+      }
+    })
+    const wrapper = mount(NMessageProvider, {
+      props: {
+        'container-style': 'padding: 24px'
+      },
+      slots: {
+        default: () => <Test />
+      }
+    })
+    void nextTick(() => {
+      const container = document.querySelector('.n-message-container')
+      expect(container).not.toBe(null)
+      expect(container.attributes.style.value).toContain('padding: 24px')
+      wrapper.unmount()
+      done()
+    })
+  })
 })


### PR DESCRIPTION
<!--
!!! Please read the following content if this is your first pull request !!!

1. If you are working on docs, please set `docs` branch as the target branch.
2. If you are working on bug fixes or new features, please set `main` branch as the target branch.

For people who are working on 2, please add changelog to `CHANGELOG.zh-CN.md` & `CHANGELOG.en-US.md` in the PR. You need to add changelog to both files. You can use English in both file. The develop team will translate it later.

About docs & changelog's format and other tips, see in `CONTRIBUTING.md`.
-->
<!--
!!! 如果这是你第一次提交 PR，请阅读下面的内容 !!!

1. 如果你在修改文档，请提交到 `docs` 分支
2. 如果你在修复 Bug 或者开发新的特性，请提交到 `main` 分支

对于进行工作 2 的人，请在 `CHANGELOG.zh-CN.md` & `CHANGELOG.en-US.md` 中添加变更日志，你需要在两个文件中都添加变更日志。你可以只使用中文，开发团队会在之后进行翻译。

关于文档和变更日志的格式以及其他的帮助信息，请参考 `CONTRIBUTING.md`。
-->
The title says it all.

Inspired by `<n-layout>`'s prop `content-style`, this allows the user to add arbitrary styles to the `<div class="n-message-container">`, allowing the user to change the position and the flex options of the container, to have fine grained control of how messages are shown.