### PR TITLE
[WIP] feat(message): Add `cssClassWrapper` prop to `Message`

### DIFF
--- a/src/message/src/Message.tsx
+++ b/src/message/src/Message.tsx
@@ -117,11 +117,12 @@ export default defineComponent({
       content,
       mergedClsPrefix,
       cssVars,
-      handleClose
+      handleClose,
+      cssClassWrapper
     } = this
     return (
       <div
-        class={`${mergedClsPrefix}-message-wrapper`}
+        class={[`${mergedClsPrefix}-message-wrapper`, cssClassWrapper]}
         style={cssVars as CSSProperties}
       >
         <div class={`${mergedClsPrefix}-message`}>

--- a/src/message/src/MessageEnvironment.tsx
+++ b/src/message/src/MessageEnvironment.tsx
@@ -82,6 +82,7 @@ export default defineComponent({
                 type={this.type}
                 icon={this.icon}
                 closable={this.closable}
+                cssClassWrapper={this.cssClassWrapper}
                 onClose={this.handleClose}
               />
             ) : null

--- a/src/message/src/message-props.ts
+++ b/src/message/src/message-props.ts
@@ -2,6 +2,9 @@ import { PropType, VNodeChild } from 'vue'
 
 export type MessageType = 'info' | 'success' | 'warning' | 'error' | 'loading'
 
+export type CssClassItem = string | Record<string, any>
+export type CssClass = CssClassItem | CssClassItem[]
+
 export const messageProps = {
   icon: Function as PropType<() => VNodeChild>,
   type: {
@@ -12,5 +15,6 @@ export const messageProps = {
   string | number | (() => VNodeChild)
   >,
   closable: Boolean,
-  onClose: Function as PropType<() => void>
+  onClose: Function as PropType<() => void>,
+  cssClassWrapper: [String, Object, Array] as PropType<CssClass>
 } as const


### PR DESCRIPTION
### Work in Progress !

Before writing tests and docs, I want to reach an agreement with the contributors if this feature and specific implementation is desirable.

This allows one to customize the style of individual messages, passing one or more custom css classes to be applied to individual messages, instead of styling them all.

Ideally I would like to be able to use completely custom elements, without requiring wrapper elements like `<div class="n-message-wrapper">` and `<div class="n-message">`.
<!--
!!! Please read the following content if this is your first pull request !!!

1. If you are working on docs, please set `docs` branch as the target branch.
2. If you are working on bug fixes or new features, please set `main` branch as the target branch.

For people who are working on 2, please add changelog to `CHANGELOG.zh-CN.md` & `CHANGELOG.en-US.md` in the PR. You need to add changelog to both files. You can use English in both file. The develop team will translate it later.

About docs & changelog's format and other tips, see in `CONTRIBUTING.md`.
-->
<!--
!!! 如果这是你第一次提交 PR，请阅读下面的内容 !!!

1. 如果你在修改文档，请提交到 `docs` 分支
2. 如果你在修复 Bug 或者开发新的特性，请提交到 `main` 分支

对于进行工作 2 的人，请在 `CHANGELOG.zh-CN.md` & `CHANGELOG.en-US.md` 中添加变更日志，你需要在两个文件中都添加变更日志。你可以只使用中文，开发团队会在之后进行翻译。

关于文档和变更日志的格式以及其他的帮助信息，请参考 `CONTRIBUTING.md`。
-->
