### PR TITLE
feat(message): Add `raw` prop to `Message`

### DIFF
--- a/src/message/src/Message.tsx
+++ b/src/message/src/Message.tsx
@@ -119,7 +119,9 @@ export default defineComponent({
       cssVars,
       handleClose
     } = this
-    return (
+    return this.raw ? (
+      render(content)
+    ) : (
       <div
         class={`${mergedClsPrefix}-message-wrapper`}
         style={cssVars as CSSProperties}

--- a/src/message/src/MessageEnvironment.tsx
+++ b/src/message/src/MessageEnvironment.tsx
@@ -81,6 +81,7 @@ export default defineComponent({
                 content={this.content}
                 type={this.type}
                 icon={this.icon}
+                raw={this.raw}
                 closable={this.closable}
                 onClose={this.handleClose}
               />

--- a/src/message/src/message-props.ts
+++ b/src/message/src/message-props.ts
@@ -11,6 +11,7 @@ export const messageProps = {
   content: [String, Number, Function] as PropType<
   string | number | (() => VNodeChild)
   >,
+  raw: Boolean,
   closable: Boolean,
   onClose: Function as PropType<() => void>
 } as const


### PR DESCRIPTION
### Work in Progress

If this feature and implementation is approved, I can work on writing tests and documentation :)

This adds a `raw` property on `NMessage`, allowing one to render completely custom elements inside of a message, without the frame and icon. But this allows one to render custom content along with other messages, without interfering/hiding them.
<!--
!!! Please read the following content if this is your first pull request !!!

1. If you are working on docs, please set `docs` branch as the target branch.
2. If you are working on bug fixes or new features, please set `main` branch as the target branch.

For people who are working on 2, please add changelog to `CHANGELOG.zh-CN.md` & `CHANGELOG.en-US.md` in the PR. You need to add changelog to both files. You can use English in both file. The develop team will translate it later.

About docs & changelog's format and other tips, see in `CONTRIBUTING.md`.
-->
<!--
!!! 如果这是你第一次提交 PR，请阅读下面的内容 !!!

1. 如果你在修改文档，请提交到 `docs` 分支
2. 如果你在修复 Bug 或者开发新的特性，请提交到 `main` 分支

对于进行工作 2 的人，请在 `CHANGELOG.zh-CN.md` & `CHANGELOG.en-US.md` 中添加变更日志，你需要在两个文件中都添加变更日志。你可以只使用中文，开发团队会在之后进行翻译。

关于文档和变更日志的格式以及其他的帮助信息，请参考 `CONTRIBUTING.md`。
-->
