### PR TITLE
Docs(NCarousel) Remove autoplay from non-autoplay examples

### DIFF
--- a/src/carousel/demos/enUS/dot-placement.demo.md
+++ b/src/carousel/demos/enUS/dot-placement.demo.md
@@ -3,7 +3,7 @@
 Set `dot-placement` to change the indication point position.
 
 ```html
-<n-carousel dot-placement="left" style="height: 240px;" autoplay>
+<n-carousel dot-placement="left" style="height: 240px;">
   <img
     class="carousel-img"
     src="https://s.anw.red/fav/1623979004.jpg!/fw/600/quality/77/ignore-error/true"

--- a/src/carousel/demos/enUS/hover.demo.md
+++ b/src/carousel/demos/enUS/hover.demo.md
@@ -1,9 +1,9 @@
 # Mouseover
 
-Set `trigger` to `hover` to trigger the switch.
+Set `trigger` to `hover` to switch when the dot is hovered over.
 
 ```html
-<n-carousel autoplay trigger="hover">
+<n-carousel trigger="hover">
   <img
     class="carousel-img"
     src="https://s.anw.red/fav/1623979004.jpg!/fw/600/quality/77/ignore-error/true"

--- a/src/carousel/demos/enUS/index.demo-entry.md
+++ b/src/carousel/demos/enUS/index.demo-entry.md
@@ -19,10 +19,10 @@ show-arrow
 | Name | Type | Default | Description |
 | --- | --- | --- | --- |
 | autoplay | `boolean` | `false` | Whether to scroll automatically. |
-| interval | `number` | `5000` | Auto play interval. |
+| interval | `number` | `5000` | Auto play interval (ms). |
 | dot-placement | `'top' \| 'bottom' \| 'left' \| 'right'` | `'bottom'` | Dot placement in the panel. |
-| show-arrow | `boolean` | `false` | Whether to show arrow button. |
-| trigger | `'click' \| 'hover'` | `'click'` | The way to trigger the switch. |
+| show-arrow | `boolean` | `false` | Whether to show arrow buttons. |
+| trigger | `'click' \| 'hover'` | `'click'` | The method of manual switching. |
 
 ### Carousel Slots
 

--- a/src/carousel/demos/zhCN/dot-placement.demo.md
+++ b/src/carousel/demos/zhCN/dot-placement.demo.md
@@ -3,7 +3,7 @@
 设定 `dot-placement` 来更改指示点位置。
 
 ```html
-<n-carousel dot-placement="left" style="height: 240px;" autoplay>
+<n-carousel dot-placement="left" style="height: 240px;">
   <img
     class="carousel-img"
     src="https://s.anw.red/fav/1623979004.jpg!/fw/600/quality/77/ignore-error/true"

--- a/src/carousel/demos/zhCN/hover.demo.md
+++ b/src/carousel/demos/zhCN/hover.demo.md
@@ -3,7 +3,7 @@
 设定 `trigger` 为 `hover` 来触发切换。
 
 ```html
-<n-carousel autoplay trigger="hover">
+<n-carousel trigger="hover">
   <img
     class="carousel-img"
     src="https://s.anw.red/fav/1623979004.jpg!/fw/600/quality/77/ignore-error/true"


### PR DESCRIPTION
I found the autoplaying confusing as to what was different between these.
I think the autoplay should be left for only the autoplay example so you can explore the specific differences of the other examples.