### PR TITLE
type(Select): update value type

### DIFF
--- a/src/select/src/Select.tsx
+++ b/src/select/src/Select.tsx
@@ -72,7 +72,7 @@ const selectProps = {
     type: [String, Number, Array] as PropType<Value | null>,
     default: null
   },
-  value: [String, Number, Array] as PropType<Value>,
+  value: [String, Number, Array] as PropType<Value | null>,
   placeholder: String,
   multiple: Boolean,
   size: String as PropType<Size>,


### PR DESCRIPTION
Fix the type mismatch problem when using null as a zero value
