### PR TITLE
chore: update deprecated deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,6 +61,8 @@
     ]
   },
   "devDependencies": {
+    "@babel/core": "^7.15.0",
+    "@babel/eslint-parser": "^7.15.0",
     "@babel/generator": "^7.12.11",
     "@babel/parser": "^7.12.11",
     "@babel/preset-env": "^7.12.10",
@@ -82,7 +84,6 @@
     "@vue/server-renderer": "^3.0.11",
     "@vue/test-utils": "^2.0.0-rc.9",
     "autoprefixer": "^10.2.6",
-    "babel-eslint": "^10.1.0",
     "babel-jest": "^27.0.2",
     "codesandbox": "^2.2.3",
     "cross-env": "^7.0.3",
@@ -94,7 +95,6 @@
     "eslint-plugin-markdown": "^2.0.0",
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-promise": "^5.1.0",
-    "eslint-plugin-standard": "^5.0.0",
     "eslint-plugin-vue": "^7.6.0",
     "express": "^4.17.1",
     "fs-extra": "^10.0.0",
@@ -103,13 +103,16 @@
     "jest": "^27.0.4",
     "lint-staged": "^11.0.0",
     "marked": "^2.0.1",
+    "postcss": "^8.3.6",
     "prettier": "^2.2.1",
     "rimraf": "^3.0.2",
+    "rollup": "^2.56.3",
     "superagent": "^6.1.0",
     "typescript": "~4.3.0",
     "vite": "^2.1.3",
     "vue": "^3.2.1",
-    "vue-router": "^4.0.5"
+    "vue-router": "^4.0.5",
+    "webpack": "^5.51.1"
   },
   "peerDependencies": {
     "vue": "^3.0.0"


### PR DESCRIPTION
In this PR,

1. deprecated packages are replaced by the successors, e.g., `babel-eslint`;
2. missing peer deps are added;
3. orphan deps are removed, e.g. `eslint-plugin-standard`.

This PR should break nothing.