### PR TITLE
chore: preserve prose wrap

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -2,4 +2,4 @@ semi: false
 singleQuote: true
 printWidth: 80
 trailingComma: "none"
-proseWrap: "never"
+proseWrap: "preserve"


### PR DESCRIPTION
Merge this PR will make Prettier format the Markdown table _correctly_, while it might also introduce few super long lines.