### PR TITLE
docs(data-table):add default-expanded-row-keys prop

### DIFF
--- a/src/data-table/demos/enUS/index.demo-entry.md
+++ b/src/data-table/demos/enUS/index.demo-entry.md
@@ -7,8 +7,8 @@ DataTable is used to displays rows of structured data.
 ## Demos
 
 <n-alert type="warning" title="Caveat" style="margin-bottom: 16px;">
-  Each item of the array passing in the <n-text code>data</n-text> prop represents a row of rendered data, and each row of data must have a unique <n-text code>key</n-text>, otherwise the <n-text code>row-key</n-text> prop must be specified on the table.
-  </n-alert>
+  Every row data needs a unique key property, otherwise you should specify <n-text code>row-key</n-text>
+</n-alert>
 
 ```demo
 basic
@@ -53,6 +53,7 @@ flex-height
 | columns | `Array<DataTableColumn>` | `[]` | Columns to display. |
 | data | `Array<object>` | `[]` | Data to display. |
 | default-checked-row-keys | `Array<string \| number>` | `[]` | The key value selected by default. |
+| default-expanded-row-keys | `Array<string \| number>` | `[]` | The key value of the expanded tree data by default |
 | flex-height | `boolean` | `false` | Whether to make table body's height auto fit table area height. Make it enabled will make `table-layout` always set to `'fixed'`. |
 | indent | `number` | `16` | Indent of row content when using tree data. |
 | loading | `boolean` | `false` | Whether to display loading status. |
@@ -97,7 +98,7 @@ flex-height
 | filterOptionValues | `Array<string \| number> \| null` | `undefined` | The active filter option values in controlled manner. If not set, the filter of the column works in an uncontrolled manner. (works when there are multiple filters). |
 | filterOptions | `Array<{ label: string, value: string \| number}>` | `undefined` | Filter options. |
 | fixed | `'left \| 'right' \| false` | `false` | Whether the column needs to be fixed. |
-| key | `string \| number` | `undefined` | Unique key of this column, this is not repeatable. |
+| key | `string \| number` | `undefined` | Unique key of this column, **required** when table's row-key is not set. |
 | options | `Array<'all' \| 'none' \| { label: string, key: string \| number, onSelect: (pageData: RowData) => void }>` | `undefined` | Options of custom selection. Only work with `type='selection'`. |
 | render | `(rowData: object, rowIndex: number) => VNodeChild` | `undefined` | Render function of column row cell. |
 | renderExpand | `(rowData: object, rowIndex: number) => VNodeChild` | `undefined` | Render function of the expand area. Only works when `type` is `'expand'`. |

--- a/src/data-table/demos/enUS/index.demo-entry.md
+++ b/src/data-table/demos/enUS/index.demo-entry.md
@@ -7,8 +7,8 @@ DataTable is used to displays rows of structured data.
 ## Demos
 
 <n-alert type="warning" title="Caveat" style="margin-bottom: 16px;">
-  Every row data needs a unique key property, otherwise you should specify <n-text code>row-key</n-text>
-</n-alert>
+  Each item of the array passing in the <n-text code>data</n-text> prop represents a row of rendered data, and each row of data must have a unique <n-text code>key</n-text>, otherwise the <n-text code>row-key</n-text> prop must be specified on the table.
+  </n-alert>
 
 ```demo
 basic
@@ -98,7 +98,7 @@ flex-height
 | filterOptionValues | `Array<string \| number> \| null` | `undefined` | The active filter option values in controlled manner. If not set, the filter of the column works in an uncontrolled manner. (works when there are multiple filters). |
 | filterOptions | `Array<{ label: string, value: string \| number}>` | `undefined` | Filter options. |
 | fixed | `'left \| 'right' \| false` | `false` | Whether the column needs to be fixed. |
-| key | `string \| number` | `undefined` | Unique key of this column, **required** when table's row-key is not set. |
+| key | `string \| number` | `undefined` | Unique key of this column, this is not repeatable. |
 | options | `Array<'all' \| 'none' \| { label: string, key: string \| number, onSelect: (pageData: RowData) => void }>` | `undefined` | Options of custom selection. Only work with `type='selection'`. |
 | render | `(rowData: object, rowIndex: number) => VNodeChild` | `undefined` | Render function of column row cell. |
 | renderExpand | `(rowData: object, rowIndex: number) => VNodeChild` | `undefined` | Render function of the expand area. Only works when `type` is `'expand'`. |

--- a/src/data-table/demos/zhCN/index.demo-entry.md
+++ b/src/data-table/demos/zhCN/index.demo-entry.md
@@ -54,6 +54,7 @@ scroll-debug
 | columns | `Array<DataTableColumn>` | `[]` | 需要展示的列 |
 | data | `Array<object>` | `[]` | 需要展示的数据 |
 | default-checked-row-keys | `Array<string \| number>` | `[]` | 默认选中的 key 值 |
+| default-expanded-row-keys | `Array<string \| number>` | `[]` | 默认展开树的 key 值 |
 | indent | `number` | `16` | 使用树形数据时行内容的缩进 |
 | flex-height | `boolean` | `false` | 是否让表格主体的高度自动适应整个表格区域的高度，打开这个选项会让 `table-layout` 始终为 `'fixed'` |
 | loading | `boolean` | `false` | 是否显示 loading 状态 |

--- a/src/data-table/demos/zhCN/index.demo-entry.md
+++ b/src/data-table/demos/zhCN/index.demo-entry.md
@@ -7,7 +7,7 @@
 ## 演示
 
 <n-alert type="warning" title="注意" style="margin-bottom: 16px;">
-  每一行数据都要有唯一的 key，否则要在 table 上声明 <n-text code>row-key</n-text> 属性
+  传入 <n-text code>data</n-text> 属性的数组的每一项都代表渲染的一行数据，每一行数据都要有唯一的 <n-text code>key</n-text>，否则需要在 table 上声明 <n-text code>row-key</n-text> 属性。
 </n-alert>
 
 ```demo
@@ -54,7 +54,6 @@ scroll-debug
 | columns | `Array<DataTableColumn>` | `[]` | 需要展示的列 |
 | data | `Array<object>` | `[]` | 需要展示的数据 |
 | default-checked-row-keys | `Array<string \| number>` | `[]` | 默认选中的 key 值 |
-| default-expanded-row-keys | `Array<string \| number>` | `[]` | 默认展开树的 key 值 |
 | indent | `number` | `16` | 使用树形数据时行内容的缩进 |
 | flex-height | `boolean` | `false` | 是否让表格主体的高度自动适应整个表格区域的高度，打开这个选项会让 `table-layout` 始终为 `'fixed'` |
 | loading | `boolean` | `false` | 是否显示 loading 状态 |
@@ -99,7 +98,7 @@ scroll-debug
 | filterOptionValues | `Array<string \| number> \| null` | `undefined` | 受控状态下，当前激活的过滤器选项值数组。如果不做设定，这一列的过滤行为将是非受控的（过滤器多选时生效） |
 | filterOptions | `Array<{ label: string, value: string \| number}>` | `undefined` | filter 的 options 数据 |
 | fixed | `'left \| 'right' \| false` | `false` | 该列是否需要 fixed |
-| key | `string \| number` | `undefined` | 这一列的 key，在表格未设定 row-key 的时候是**必须**的。 |
+| key | `string \| number` | `undefined` | 这一列的 key，不可重复。 |
 | options | `Array<'all' \| 'none' \| { label: string, key: string \| number, onSelect: (pageData: RowData) => void }>` | `undefined` | 自定义选择项的选项，只对 `type='selection'` 生效 |
 | render | `(rowData: object, rowIndex: number) => VNodeChild` | `undefined` | 渲染函数，渲染这一列的每一行的单元格 |
 | renderExpand | `(rowData: object, rowIndex: number) => VNodeChild` | `undefined` | 展开区域的渲染函数，仅在 `type` 为 `'expand'` 的时候生效 |

--- a/src/data-table/demos/zhCN/index.demo-entry.md
+++ b/src/data-table/demos/zhCN/index.demo-entry.md
@@ -7,7 +7,7 @@
 ## 演示
 
 <n-alert type="warning" title="注意" style="margin-bottom: 16px;">
-  传入 <n-text code>data</n-text> 属性的数组的每一项都代表渲染的一行数据，每一行数据都要有唯一的 <n-text code>key</n-text>，否则需要在 table 上声明 <n-text code>row-key</n-text> 属性。
+  每一行数据都要有唯一的 key，否则要在 table 上声明 <n-text code>row-key</n-text> 属性
 </n-alert>
 
 ```demo
@@ -54,6 +54,7 @@ scroll-debug
 | columns | `Array<DataTableColumn>` | `[]` | 需要展示的列 |
 | data | `Array<object>` | `[]` | 需要展示的数据 |
 | default-checked-row-keys | `Array<string \| number>` | `[]` | 默认选中的 key 值 |
+| default-expanded-row-keys | `Array<string \| number>` | `[]` | 默认展开树的 key 值 |
 | indent | `number` | `16` | 使用树形数据时行内容的缩进 |
 | flex-height | `boolean` | `false` | 是否让表格主体的高度自动适应整个表格区域的高度，打开这个选项会让 `table-layout` 始终为 `'fixed'` |
 | loading | `boolean` | `false` | 是否显示 loading 状态 |
@@ -98,7 +99,7 @@ scroll-debug
 | filterOptionValues | `Array<string \| number> \| null` | `undefined` | 受控状态下，当前激活的过滤器选项值数组。如果不做设定，这一列的过滤行为将是非受控的（过滤器多选时生效） |
 | filterOptions | `Array<{ label: string, value: string \| number}>` | `undefined` | filter 的 options 数据 |
 | fixed | `'left \| 'right' \| false` | `false` | 该列是否需要 fixed |
-| key | `string \| number` | `undefined` | 这一列的 key，不可重复。 |
+| key | `string \| number` | `undefined` | 这一列的 key，在表格未设定 row-key 的时候是**必须**的。 |
 | options | `Array<'all' \| 'none' \| { label: string, key: string \| number, onSelect: (pageData: RowData) => void }>` | `undefined` | 自定义选择项的选项，只对 `type='selection'` 生效 |
 | render | `(rowData: object, rowIndex: number) => VNodeChild` | `undefined` | 渲染函数，渲染这一列的每一行的单元格 |
 | renderExpand | `(rowData: object, rowIndex: number) => VNodeChild` | `undefined` | 展开区域的渲染函数，仅在 `type` 为 `'expand'` 的时候生效 |


### PR DESCRIPTION
data-table文档缺失default-expanded-row-keys #1068 
