### PR TITLE
Fix: Add border transition on the drawer

### DIFF
--- a/src/drawer/src/styles/index.cssr.ts
+++ b/src/drawer/src/styles/index.cssr.ts
@@ -76,6 +76,7 @@ export default c([
         font-size: var(--title-font-size);
         color: var(--title-text-color);
         padding: var(--header-padding);
+        transition: border .3s var(--bezier);
         border-bottom: 1px solid var(--divider-color);
         border-bottom: var(--header-border-bottom);
         display: flex;
@@ -91,6 +92,7 @@ export default c([
         display: flex;
         justify-content: flex-end;
         border-top: var(--footer-border-top);
+        transition: border .3s var(--bezier);
         padding: var(--footer-padding);
       `)
     ]),


### PR DESCRIPTION
### Description
This branch is aiming to fix this issue #1211. It simply adds some border transition on the header and footer of the drawer.

### With the transition
![Kapture 2021-09-21 at 19 54 22](https://user-images.githubusercontent.com/29732250/134222543-8a9791ed-75dd-4c93-9dd2-5d2fe08de123.gif)

