### PR TITLE
Accessibility/improve aria for alert

### DIFF
--- a/CHANGELOG.en-US.md
+++ b/CHANGELOG.en-US.md
@@ -5,6 +5,7 @@
 ### Fixes
 
 - Fix `n-global-style` applies style transition on first mount.
+- Fix `n-alert` aria support
 
 ## 2.19.1 (2021-09-21)
 

--- a/src/alert/src/Alert.tsx
+++ b/src/alert/src/Alert.tsx
@@ -165,56 +165,57 @@ export default defineComponent({
                         [`${mergedClsPrefix}-alert--show-icon`]: this.showIcon
                       }
                   ],
-                  style: this.cssVars
+                  style: this.cssVars,
+                  role: 'alert'
                 }),
                 [
                   this.closable ? (
-                    <NBaseClose
-                      clsPrefix={mergedClsPrefix}
-                      class={`${mergedClsPrefix}-alert__close`}
-                      onClick={this.handleCloseClick}
-                    />
+                      <NBaseClose
+                        clsPrefix={mergedClsPrefix}
+                        class={`${mergedClsPrefix}-alert__close`}
+                        onClick={this.handleCloseClick}
+                      />
                   ) : null,
                   this.showIcon ? (
-                    <div class={`${mergedClsPrefix}-alert__icon`}>
-                      {this.$slots.icon ? (
-                        renderSlot(this.$slots, 'icon')
-                      ) : (
-                        <NBaseIcon clsPrefix={mergedClsPrefix}>
-                          {{
-                            default: () => {
-                              switch (this.type) {
-                                case 'success':
-                                  return <SuccessIcon />
-                                case 'info':
-                                  return <InfoIcon />
-                                case 'warning':
-                                  return <WarningIcon />
-                                case 'error':
-                                  return <ErrorIcon />
-                                default:
-                                  return null
+                      <div class={`${mergedClsPrefix}-alert__icon`}>
+                        {this.$slots.icon ? (
+                          renderSlot(this.$slots, 'icon')
+                        ) : (
+                          <NBaseIcon clsPrefix={mergedClsPrefix}>
+                            {{
+                              default: () => {
+                                switch (this.type) {
+                                  case 'success':
+                                    return <SuccessIcon />
+                                  case 'info':
+                                    return <InfoIcon />
+                                  case 'warning':
+                                    return <WarningIcon />
+                                  case 'error':
+                                    return <ErrorIcon />
+                                  default:
+                                    return null
+                                }
                               }
-                            }
-                          }}
-                        </NBaseIcon>
-                      )}
-                    </div>
+                            }}
+                          </NBaseIcon>
+                        )}
+                      </div>
                   ) : null,
-                  <div class={`${mergedClsPrefix}-alert-body`}>
-                    {this.title !== undefined ? (
-                      <div class={`${mergedClsPrefix}-alert-body__title`}>
-                        {renderSlot(this.$slots, 'header', undefined, () => [
-                          this.title
-                        ])}
-                      </div>
-                    ) : null}
-                    {this.$slots.default ? (
-                      <div class={`${mergedClsPrefix}-alert-body__content`}>
-                        {this.$slots}
-                      </div>
-                    ) : null}
-                  </div>
+                    <div class={`${mergedClsPrefix}-alert-body`}>
+                      {this.title !== undefined ? (
+                        <div class={`${mergedClsPrefix}-alert-body__title`}>
+                          {renderSlot(this.$slots, 'header', undefined, () => [
+                            this.title
+                          ])}
+                        </div>
+                      ) : null}
+                      {this.$slots.default ? (
+                        <div class={`${mergedClsPrefix}-alert-body__content`}>
+                          {this.$slots}
+                        </div>
+                      ) : null}
+                    </div>
                 ] as any
               )
               : null

--- a/src/alert/src/Alert.tsx
+++ b/src/alert/src/Alert.tsx
@@ -177,7 +177,10 @@ export default defineComponent({
                       />
                   ) : null,
                   this.showIcon ? (
-                      <div class={`${mergedClsPrefix}-alert__icon`}>
+                      <div
+                        class={`${mergedClsPrefix}-alert__icon`}
+                        aria-hidden="true"
+                      >
                         {this.$slots.icon ? (
                           renderSlot(this.$slots, 'icon')
                         ) : (

--- a/src/alert/tests/Alert.spec.ts
+++ b/src/alert/tests/Alert.spec.ts
@@ -14,6 +14,13 @@ describe('n-alert', () => {
     expect(wrapper.find('.n-alert').attributes('role')).toBe('alert')
   })
 
+  it('should add the right aria', () => {
+    const wrapper = mount(NAlert)
+    expect(wrapper.find('.n-alert__icon').attributes('aria-hidden')).toBe(
+      'true'
+    )
+  })
+
   it('shouldnt have default title', () => {
     const wrapper = mount(NAlert)
     expect(wrapper.find('.n-alert-body__title').exists()).toBe(false)

--- a/src/alert/tests/Alert.spec.ts
+++ b/src/alert/tests/Alert.spec.ts
@@ -9,6 +9,11 @@ describe('n-alert', () => {
     mount(NAlert)
   })
 
+  it('should have a role of "alert"', () => {
+    const wrapper = mount(NAlert)
+    expect(wrapper.find('.n-alert').attributes('role')).toBe('alert')
+  })
+
   it('shouldnt have default title', () => {
     const wrapper = mount(NAlert)
     expect(wrapper.find('.n-alert-body__title').exists()).toBe(false)


### PR DESCRIPTION
### Description
Here is a PR to improve the accessibility of the Alert component. This is linked to this issue #41.

### Implementation
I used this as a reference https://www.w3.org/TR/wai-aria-practices-1.1/#alert. 
Two things were missing:
- `role="alert"` on the alert wrapper
- `aria-hidden` for the icon wrapper