### PR TITLE
Accessibility/improve aria for checkbox

### DIFF
--- a/CHANGELOG.en-US.md
+++ b/CHANGELOG.en-US.md
@@ -11,6 +11,7 @@
 - Fix `n-global-style` applies style transition on first mount.
 - Fix `n-drawer` border transition [#1211].
 - Fix `n-alert` aria support.
+- Fix `n-checkbox` aria support.
 
 ## 2.19.1 (2021-09-21)
 

--- a/src/checkbox/src/Checkbox.tsx
+++ b/src/checkbox/src/Checkbox.tsx
@@ -285,7 +285,7 @@ export default defineComponent({
         ]}
         tabindex={mergedDisabled || !focusable ? undefined : 0}
         role="checkbox"
-        aria-checked={renderedChecked}
+        aria-checked={indeterminate ? 'mixed' : renderedChecked}
         style={cssVars as CSSProperties}
         onKeyup={handleKeyUp}
         onKeydown={handleKeyDown}

--- a/src/checkbox/src/Checkbox.tsx
+++ b/src/checkbox/src/Checkbox.tsx
@@ -285,6 +285,7 @@ export default defineComponent({
         ]}
         tabindex={mergedDisabled || !focusable ? undefined : 0}
         role="checkbox"
+        aria-checked={renderedChecked}
         style={cssVars as CSSProperties}
         onKeyup={handleKeyUp}
         onKeydown={handleKeyDown}

--- a/src/checkbox/src/Checkbox.tsx
+++ b/src/checkbox/src/Checkbox.tsx
@@ -10,6 +10,7 @@ import {
   CSSProperties
 } from 'vue'
 import { useMergedState, useMemo } from 'vooks'
+import { createId } from 'seemly'
 import { useConfig, useFormItem, useTheme } from '../../_mixins'
 import type { ThemeProps } from '../../_mixins'
 import { NIconSwitchTransition } from '../../_internal'
@@ -153,6 +154,7 @@ export default defineComponent({
       props,
       mergedClsPrefixRef
     )
+
     function toggle (e: MouseEvent | KeyboardEvent): void {
       if (NCheckboxGroup && props.value !== undefined) {
         NCheckboxGroup.toggleCheckbox(!renderedCheckedRef.value, props.value)
@@ -197,6 +199,7 @@ export default defineComponent({
       mergedDisabled: mergedDisabledRef,
       renderedChecked: renderedCheckedRef,
       mergedTheme: themeRef,
+      labelId: `n-checkbox-label-${createId(4)}`,
       handleClick,
       handleKeyUp,
       handleKeyDown,
@@ -265,6 +268,7 @@ export default defineComponent({
       indeterminate,
       privateTableHeader,
       cssVars,
+      labelId,
       label,
       mergedClsPrefix,
       focusable,
@@ -286,6 +290,7 @@ export default defineComponent({
         tabindex={mergedDisabled || !focusable ? undefined : 0}
         role="checkbox"
         aria-checked={indeterminate ? 'mixed' : renderedChecked}
+        aria-labelledby={labelId}
         style={cssVars as CSSProperties}
         onKeyup={handleKeyUp}
         onKeydown={handleKeyDown}
@@ -321,7 +326,7 @@ export default defineComponent({
           <div class={`${mergedClsPrefix}-checkbox-box__border`} />
         </div>
         {label !== null || $slots.default ? (
-          <span class={`${mergedClsPrefix}-checkbox__label`}>
+          <span class={`${mergedClsPrefix}-checkbox__label`} id={labelId}>
             {renderSlot($slots, 'default', undefined, () => [label])}
           </span>
         ) : null}

--- a/src/checkbox/src/Checkbox.tsx
+++ b/src/checkbox/src/Checkbox.tsx
@@ -284,6 +284,7 @@ export default defineComponent({
           }
         ]}
         tabindex={mergedDisabled || !focusable ? undefined : 0}
+        role="checkbox"
         style={cssVars as CSSProperties}
         onKeyup={handleKeyUp}
         onKeydown={handleKeyDown}

--- a/src/checkbox/src/CheckboxGroup.tsx
+++ b/src/checkbox/src/CheckboxGroup.tsx
@@ -161,7 +161,9 @@ export default defineComponent({
   },
   render () {
     return (
-      <div class={`${this.mergedClsPrefix}-checkbox-group`}>{this.$slots}</div>
+      <div class={`${this.mergedClsPrefix}-checkbox-group`} role="group">
+        {this.$slots}
+      </div>
     )
   }
 })

--- a/src/checkbox/tests/Checkbox.spec.tsx
+++ b/src/checkbox/tests/Checkbox.spec.tsx
@@ -15,11 +15,6 @@ describe('n-checkbox', () => {
     mount(NCheckbox)
   })
 
-  it('should have a role of "checkbox"', () => {
-    const wrapper = mount(NCheckbox)
-    expect(wrapper.find('.n-checkbox').attributes('role')).toBe('checkbox')
-  })
-
   describe('uncontrolled mode', () => {
     it('works', async () => {
       const wrapper = mount(NCheckbox)
@@ -144,6 +139,29 @@ describe('n-checkbox', () => {
     ))
 
     expect(wrapper.find('.n-checkbox').attributes('style')).toMatchSnapshot()
+  })
+
+  describe('accessibility', () => {
+    it('should have a role of "checkbox"', () => {
+      const wrapper = mount(NCheckbox)
+      expect(wrapper.find('.n-checkbox').attributes('role')).toBe('checkbox')
+    })
+
+    it('should set a default aria-labelledby', () => {
+      const labelId = 'custom-id'
+      const wrapper = mount(() => <NCheckbox aria-labelledby={labelId} />)
+      expect(wrapper.find('.n-checkbox').attributes('aria-labelledby')).toMatch(
+        labelId
+      )
+    })
+
+    it('should allow to set aria-labelledby from outside', () => {
+      const wrapper = mount(NCheckbox)
+      const labelId = wrapper.find('.n-checkbox__label').attributes('id')
+      expect(wrapper.find('.n-checkbox').attributes('aria-labelledby')).toBe(
+        labelId
+      )
+    })
   })
 })
 

--- a/src/checkbox/tests/Checkbox.spec.tsx
+++ b/src/checkbox/tests/Checkbox.spec.tsx
@@ -170,6 +170,11 @@ describe('n-checkbox-group', () => {
     mount(NCheckboxGroup)
   })
 
+  it('should have a role of "group"', () => {
+    const wrapper = mount(NCheckboxGroup)
+    expect(wrapper.find('.n-checkbox-group').attributes('role')).toBe('group')
+  })
+
   it('should work with `disabled` prop', () => {
     const wrapper = mount(NCheckboxGroup, {
       props: {

--- a/src/checkbox/tests/Checkbox.spec.tsx
+++ b/src/checkbox/tests/Checkbox.spec.tsx
@@ -51,6 +51,7 @@ describe('n-checkbox', () => {
     expect(wrapper.find('.n-checkbox').classes()).toContain(
       'n-checkbox--indeterminate'
     )
+    expect(wrapper.find('.n-checkbox').attributes('aria-checked')).toBe('mixed')
   })
 
   it('should work with `disabled` prop', () => {

--- a/src/checkbox/tests/Checkbox.spec.tsx
+++ b/src/checkbox/tests/Checkbox.spec.tsx
@@ -5,6 +5,9 @@ import { NForm, NFormItem } from '../../form'
 
 function expectChecked (wrapper: VueWrapper<any>, value: boolean): void {
   expect(wrapper.classes().some((c) => c.includes('checked'))).toEqual(value)
+  expect(wrapper.find('.n-checkbox').attributes('aria-checked')).toBe(
+    value.toString()
+  )
 }
 
 describe('n-checkbox', () => {

--- a/src/checkbox/tests/Checkbox.spec.tsx
+++ b/src/checkbox/tests/Checkbox.spec.tsx
@@ -12,6 +12,11 @@ describe('n-checkbox', () => {
     mount(NCheckbox)
   })
 
+  it('should have a role of "checkbox"', () => {
+    const wrapper = mount(NCheckbox)
+    expect(wrapper.find('.n-checkbox').attributes('role')).toBe('checkbox')
+  })
+
   describe('uncontrolled mode', () => {
     it('works', async () => {
       const wrapper = mount(NCheckbox)


### PR DESCRIPTION
### Description
Add better aria-support for `n-checkbox` and `n-checkbox-group`. Followed this guide w3.org/TR/wai-aria-practices-1.1/examples/checkbox/checkbox-1/checkbox-1.html.

#### NCheckboxGroup
- Added a `role="group"`

#### NCheckbox
- Added a `role="checkbox"`
- Added `aria-labelledby="some-if"`. By default, we will give a custom id (Ex: `n-checbox-label-CBMZ`) to the label wrapper so we can reference this label in the aria attribute.
- Added `aria-checked` with the value of `true` or `false` and `mixed` if the checkbox is in an intermediate state.

### Result
#41 . Now it should be better for the browser to understand the checkbox input.
![Screen Shot 2021-09-23 at 10 37 13 AM](https://user-images.githubusercontent.com/29732250/134477488-436ed574-9158-4430-9461-dd40c09235af.png)

### Consideration
One thing we can do is to refactor the component to use `<input/>` and `<label>` to have a better semantic and some accessibility features out of the box.
Like something like this for example
```html
<div>
  <div class="hidden-accessible">
     <input type="checkbox" value="Chicago" id="city1" name="city">
  </div>
  <div class="checkbox-box" role="checkbox" aria-checked="false">
    <span class="checkbox-icon"></span>
  </div>
  <label for="city1">Chicago</label>
</div>
```