### PR TITLE
feat(layoutSider): add ToggleButtonTextColor

### DIFF
--- a/CHANGELOG.en-US.md
+++ b/CHANGELOG.en-US.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+### Fixes
+
+- Fix `n-layout-sider`'s `arrow-circle`'s font style.
+
 ## 2.19.2 (2021-09-26)
 
 ### i18n

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+### Fixes
+
+- 修复 `n-layout-sider` 中 `arrow-circle` 的字体样式
+
 ## 2.19.2 (2021-09-26)
 
 ### i18n

--- a/src/layout/src/LayoutSider.tsx
+++ b/src/layout/src/LayoutSider.tsx
@@ -207,6 +207,7 @@ export default defineComponent({
         const {
           siderToggleButtonColor,
           siderToggleButtonBorder,
+          siderToggleButtonTextColor,
           siderToggleBarColor,
           siderToggleBarColorHover
         } = self
@@ -214,6 +215,7 @@ export default defineComponent({
           '--bezier': cubicBezierEaseInOut,
           '--toggle-button-color': siderToggleButtonColor,
           '--toggle-button-border': siderToggleButtonBorder,
+          '--toggle-button-text-color': siderToggleButtonTextColor,
           '--toggle-bar-color': siderToggleBarColor,
           '--toggle-bar-color-hover': siderToggleBarColorHover
         }

--- a/src/layout/src/LayoutSider.tsx
+++ b/src/layout/src/LayoutSider.tsx
@@ -207,7 +207,6 @@ export default defineComponent({
         const {
           siderToggleButtonColor,
           siderToggleButtonBorder,
-          siderToggleButtonTextColor,
           siderToggleBarColor,
           siderToggleBarColorHover
         } = self
@@ -215,7 +214,6 @@ export default defineComponent({
           '--bezier': cubicBezierEaseInOut,
           '--toggle-button-color': siderToggleButtonColor,
           '--toggle-button-border': siderToggleButtonBorder,
-          '--toggle-button-text-color': siderToggleButtonTextColor,
           '--toggle-bar-color': siderToggleBarColor,
           '--toggle-bar-color-hover': siderToggleBarColorHover
         }
@@ -223,11 +221,13 @@ export default defineComponent({
           vars['--color'] = self.siderColorInverted
           vars['--text-color'] = self.textColorInverted
           vars['--border-color'] = self.siderBorderColorInverted
+          vars['--toggle-button-icon-color'] = self.siderToggleButtonIconColorInverted
           vars.__invertScrollbar = self.__invertScrollbar
         } else {
           vars['--color'] = self.siderColor
           vars['--text-color'] = self.textColor
           vars['--border-color'] = self.siderBorderColor
+          vars['--toggle-button-icon-color'] = self.siderToggleButtonIconColor
         }
         return vars
       }),

--- a/src/layout/src/styles/layout-sider.cssr.ts
+++ b/src/layout/src/styles/layout-sider.cssr.ts
@@ -106,7 +106,7 @@ export default cB('layout-sider', `
     align-items: center;
     justify-content: center;
     font-size: 18px;
-    color: var(--toggle-button-text-color);
+    color: var(--toggle-button-icon-color);
     border: var(--toggle-button-border);
     background-color: var(--toggle-button-color);
     box-shadow: 0 2px 4px 0px rgba(0, 0, 0, .06);

--- a/src/layout/src/styles/layout-sider.cssr.ts
+++ b/src/layout/src/styles/layout-sider.cssr.ts
@@ -106,7 +106,7 @@ export default cB('layout-sider', `
     align-items: center;
     justify-content: center;
     font-size: 18px;
-    color: var(--text-color);
+    color: var(--toggle-button-text-color);
     border: var(--toggle-button-border);
     background-color: var(--toggle-button-color);
     box-shadow: 0 2px 4px 0px rgba(0, 0, 0, .06);

--- a/src/layout/styles/dark.ts
+++ b/src/layout/styles/dark.ts
@@ -38,6 +38,7 @@ const layoutDark: LayoutTheme = {
       siderColorInverted: cardColor,
       siderToggleButtonBorder: '1px solid transparent',
       siderToggleButtonColor: popoverColor,
+      siderToggleButtonTextColor: textColor2,
       siderToggleBarColor: composite(bodyColor, scrollbarColor),
       siderToggleBarColorHover: composite(bodyColor, scrollbarColorHover),
       __invertScrollbar: 'false'

--- a/src/layout/styles/dark.ts
+++ b/src/layout/styles/dark.ts
@@ -38,7 +38,8 @@ const layoutDark: LayoutTheme = {
       siderColorInverted: cardColor,
       siderToggleButtonBorder: '1px solid transparent',
       siderToggleButtonColor: popoverColor,
-      siderToggleButtonTextColor: textColor2,
+      siderToggleButtonIconColor: textColor2,
+      siderToggleButtonIconColorInverted: textColor2,
       siderToggleBarColor: composite(bodyColor, scrollbarColor),
       siderToggleBarColorHover: composite(bodyColor, scrollbarColorHover),
       __invertScrollbar: 'false'

--- a/src/layout/styles/light.ts
+++ b/src/layout/styles/light.ts
@@ -35,7 +35,8 @@ export const self = (vars: ThemeCommonVars) => {
     siderColorInverted: invertedColor,
     siderToggleButtonBorder: `1px solid ${dividerColor}`,
     siderToggleButtonColor: baseColor,
-    siderToggleButtonTextColor: textColor2,
+    siderToggleButtonIconColor: textColor2,
+    siderToggleButtonIconColorInverted: invertedColor,
     siderToggleBarColor: composite(bodyColor, scrollbarColor),
     siderToggleBarColorHover: composite(bodyColor, scrollbarColorHover),
     // hack for inverted background

--- a/src/layout/styles/light.ts
+++ b/src/layout/styles/light.ts
@@ -35,6 +35,7 @@ export const self = (vars: ThemeCommonVars) => {
     siderColorInverted: invertedColor,
     siderToggleButtonBorder: `1px solid ${dividerColor}`,
     siderToggleButtonColor: baseColor,
+    siderToggleButtonTextColor: textColor2,
     siderToggleBarColor: composite(bodyColor, scrollbarColor),
     siderToggleBarColorHover: composite(bodyColor, scrollbarColorHover),
     // hack for inverted background


### PR DESCRIPTION
不知这么处理是否合适，还请多多指教。
问题：layoutSider 在 inverted 模式下，siderToggleButton的字体颜色会变成白色，跟背景融合在一起。可查看文档中的反转案例。[文档地址](https://www.naiveui.com/zh-CN/os-theme/components/layout)
解决方式：添加了siderToggleButtonTextColor，默认为textColor2。使其颜色与layout的textColor解耦，同时跟siderToggleBar一样可单独设置样式。

Question: Under the inverted mode of layoutSider, the font color of siderToggleButton would turn white and merge with its backgroundColor.    
Solution: Add siderToggleButtonTextColor, textColor2 on by default.  Decouple the color inherited from the Layout's textColor, and we can set its style separately, same with siderToggleBar.  