### PR TITLE
ci:add node 16 to matrix

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -17,7 +17,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [12.x, 14.x]
+        node-version: [12.x, 14.x, 16.x]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:
@@ -30,7 +30,7 @@ jobs:
     - run: pnpm install
     - run: pnpm run lint
     - run: pnpm run test:cov
-    - uses: codecov/codecov-action@v1.5.2
+    - uses: codecov/codecov-action@v2.1.0
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
 


### PR DESCRIPTION
1. node 16 has become the LTS version 
https://nodejs.org/en/about/releases/
2. action `codecov/codecov-action` has new version @v2.1.0 
https://github.com/codecov/codecov-action/releases
