### PR TITLE
Update styles to bypass Vitejs bug on string interpolation

### DIFF
--- a/CHANGELOG.en-US.md
+++ b/CHANGELOG.en-US.md
@@ -7,6 +7,7 @@
 - `n-data-table` add `striped` prop, closes [#1552](https://github.com/TuSimple/naive-ui/issues/1552).
 - `n-slider` add `vertical` prop, closes [#1468](https://github.com/TuSimple/naive-ui/issues/1468).
 - `n-slider` add `reverse` prop.
+- Bypass Vitejs bug on string extrapolation, [#636](https://github.com/TuSimple/naive-ui/issues/636).
 
 ## 2.20.3 (2021-11-15)
 

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -7,6 +7,7 @@
 - `n-data-table` 新增 `striped` 属性，关闭 [#1552](https://github.com/TuSimple/naive-ui/issues/1552)
 - `n-slider` 新增 `vertical` 属性，关闭 [#1468](https://github.com/TuSimple/naive-ui/issues/1468)
 - `n-slider` 新增 `reverse` 属性
+- Bypass Vitejs bug on string extrapolation, [#636](https://github.com/TuSimple/naive-ui/issues/636).
 
 ## 2.20.3 (2021-11-15)
 

--- a/src/_styles/global/index.cssr.ts
+++ b/src/_styles/global/index.cssr.ts
@@ -1,6 +1,12 @@
 import { c } from '../../_utils/cssr'
 import commonVariables from '../common/_common'
 
+const {
+  fontSize,
+  fontFamily,
+  lineHeight
+} = commonVariables
+
 // All the components need the style
 // It is static and won't be changed in the app's lifetime
 // If user want to overrides it they need to use `n-global-style` is provided
@@ -13,9 +19,9 @@ import commonVariables from '../common/_common'
 // In some android devices, there will be the style.
 export default c('body', `
   margin: 0;
-  font-size: ${commonVariables.fontSize};
-  font-family: ${commonVariables.fontFamily};
-  line-height: ${commonVariables.lineHeight};
+  font-size: ${fontSize};
+  font-family: ${fontFamily};
+  line-height: ${lineHeight};
   -webkit-text-size-adjust: 100%;
   -webkit-tap-highlight-color: transparent;
 `, [

--- a/src/_styles/transitions/icon-switch.cssr.ts
+++ b/src/_styles/transitions/icon-switch.cssr.ts
@@ -2,6 +2,11 @@ import { CNode } from 'css-render'
 import { c } from '../../_utils/cssr'
 import commonVariables from '../common/_common'
 
+const {
+  cubicBezierEaseInOut,
+  transformDebounceScale
+} = commonVariables
+
 interface IconSwitchTransitionOptions {
   originalTransform?: string
   left?: string | number
@@ -13,7 +18,7 @@ export default function ({
   originalTransform = '',
   left = 0,
   top = 0,
-  transition = `all .3s ${commonVariables.cubicBezierEaseInOut} !important`
+  transition = `all .3s ${cubicBezierEaseInOut} !important`
 }: IconSwitchTransitionOptions = {}): CNode[] {
   return [
     c('&.icon-switch-transition-enter-from, &.icon-switch-transition-leave-to', {
@@ -23,7 +28,7 @@ export default function ({
       opacity: 0
     }),
     c('&.icon-switch-transition-enter-to, &.icon-switch-transition-leave-from', {
-      transform: `${commonVariables.transformDebounceScale} ${originalTransform}`,
+      transform: `${transformDebounceScale} ${originalTransform}`,
       left,
       top,
       opacity: 1


### PR DESCRIPTION
Hi,
There is a bug on Vitejs when using a javascript object in string interpolation.
Therefore when building Nuxt app with Vitejs, we got an undefined commonVariables.
This PR solves this problem and should solve #636 
In defineNuxtConfig function we don't need to add vite: false anymore.