### PR TITLE
docs: Add missing types to 'preset' of Modal props

### DIFF
--- a/src/modal/demos/enUS/index.demo-entry.md
+++ b/src/modal/demos/enUS/index.demo-entry.md
@@ -23,7 +23,7 @@ transform-origin
 | --- | --- | --- | --- |
 | display-directive | `'if' \| 'show'` | `'if'` | Use which directive to control the rendering of modal body. |
 | mask-closable | `boolean` | `true` | Whether to emit `hide` event when click mask. |
-| preset | `'card' \| 'confirm'` | `undefined` | The preset of `n-modal`. |
+| preset | `'dialog' \| 'card' \| 'confirm'` | `undefined` | The preset of `n-modal`. |
 | show | `boolean` | `false` | Whether to show modal. |
 | to | `string \| HTMLElement` | `body` | Container node of the modal content. |
 | transform-origin | `'mouse' \| 'center'` | `'mouse'` | The transform origin of the modal's display animation. |

--- a/src/modal/demos/zhCN/index.demo-entry.md
+++ b/src/modal/demos/zhCN/index.demo-entry.md
@@ -35,7 +35,7 @@ dark-10-debug
 | --- | --- | --- | --- |
 | display-directive | `'if' \| 'show'` | `'if'` | 使用何种指令控制模态框主体的条件渲染 |
 | mask-closable | `boolean` | `true` | 点击遮罩时是否发出 `update:show` 事件 |
-| preset | `'card' \| 'dialog'` | `undefined` | 模态框使用何种预设 |
+| preset | `'dialog' \| 'card' \| 'confirm'` | `undefined` | 模态框使用何种预设 |
 | show | `boolean` | `false` | 是否展示 Modal |
 | to | `string \| HTMLElement` | `body` | Modal 的挂载位置 |
 | transform-origin | `'mouse' \| 'center'` | `'mouse'` | 模态框动画出现的位置 |


### PR DESCRIPTION
<!--
!!! Please read the following content if this is your first pull request !!!

1. If you are working on docs, please set `docs` branch as the target branch.
2. If you are working on bug fixes or new features, please set `main` branch as the target branch.

For people who are working on 2, please add changelog to `CHANGELOG.zh-CN.md` & `CHANGELOG.en-US.md` in the PR. You need to add changelog to both files. You can use English in both file. The develop team will translate it later.

About docs & changelog's format and other tips, see in `CONTRIBUTING.md`.
-->
<!--
!!! 如果这是你第一次提交 PR，请阅读下面的内容 !!!

1. 如果你在修改文档，请提交到 `docs` 分支
2. 如果你在修复 Bug 或者开发新的特性，请提交到 `main` 分支

对于进行工作 2 的人，请在 `CHANGELOG.zh-CN.md` & `CHANGELOG.en-US.md` 中添加变更日志，你需要在两个文件中都添加变更日志。你可以只使用中文，开发团队会在之后进行翻译。

关于文档和变更日志的格式以及其他的帮助信息，请参考 `CONTRIBUTING.md`。
-->
