### PR TITLE
ci: use check-issue-ref enable tacking issue

### DIFF
--- a/.github/workflows/issue-open-check.yml
+++ b/.github/workflows/issue-open-check.yml
@@ -13,7 +13,7 @@ jobs:
       - run: echo opened by ${{ steps.check.outputs.result }}
 
       - name: check format
-        if: (contains(github.event.issue.body, 'issue-helper') == false&&steps.check.outputs.result == 0)
+        if: (contains(github.event.issue.body, 'issue-helper') == false && steps.check.outputs.result == 0)
         uses: actions-cool/issues-helper@v2.5.0
         with:
           actions: 'create-comment,add-labels,close-issue'

--- a/.github/workflows/issue-open-check.yml
+++ b/.github/workflows/issue-open-check.yml
@@ -8,9 +8,13 @@ jobs:
   check-issue:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions-cool/check-issue-ref@v1
+        id: check
+      - run: echo opened by ${{ steps.check.outputs.result }}
+
       - name: check format
-        if: (contains(github.event.issue.body, 'issue-helper') == false)
-        uses: actions-cool/issues-helper@v2.2.1
+        if: (contains(github.event.issue.body, 'issue-helper') == false&&steps.check.outputs.result == 0)
+        uses: actions-cool/issues-helper@v2.5.0
         with:
           actions: 'create-comment,add-labels,close-issue'
           issue-number: ${{ github.event.issue.number }}


### PR DESCRIPTION
Signed-off-by: Sepush <sepush@outlook.com>

use `check-issue-ref` to get the issue ref
enable issue opened by tacking issue convert to issue
<!--
!!! Please read the following content if this is your first pull request !!!

1. If you are working on docs, please set `docs` branch as the target branch.
2. If you are working on bug fixes or new features, please set `main` branch as the target branch.

For people who are working on 2, please add changelog to `CHANGELOG.zh-CN.md` & `CHANGELOG.en-US.md` in the PR. You need to add changelog to both files. You can use English in both file. The develop team will translate it later.

About docs & changelog's format and other tips, see in `CONTRIBUTING.md`.
-->
<!--
!!! 如果这是你第一次提交 PR，请阅读下面的内容 !!!

1. 如果你在修改文档，请提交到 `docs` 分支
2. 如果你在修复 Bug 或者开发新的特性，请提交到 `main` 分支

对于进行工作 2 的人，请在 `CHANGELOG.zh-CN.md` & `CHANGELOG.en-US.md` 中添加变更日志，你需要在两个文件中都添加变更日志。你可以只使用中文，开发团队会在之后进行翻译。

关于文档和变更日志的格式以及其他的帮助信息，请参考 `CONTRIBUTING.md`。
-->
