### PR TITLE
docs: use native anchor and form elements

### DIFF
--- a/demo/utils/EditInCodeSandboxButton.vue
+++ b/demo/utils/EditInCodeSandboxButton.vue
@@ -1,31 +1,39 @@
 <template>
-  <n-button
-    class="edit-button"
-    text
-    :size="size"
-    @click="handleClick"
-    depth="3"
+  <form
+    action="https://codesandbox.io/api/v1/sandboxes/define"
+    method="POST"
+    target="_blank"
+    style="display: flex"
   >
-    <template #icon>
-      <n-icon>
-        <svg
-          width="512"
-          height="512"
-          viewBox="0 0 512 512"
-          fill="none"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M69 153.99L256 263.99M256 263.99L443 153.99M256 263.99V463.99M448 341.37V170.61C447.993 165.021 446.523 159.531 443.735 154.687C440.947 149.843 436.939 145.814 432.11 143L280.11 54.54C272.787 50.2765 264.464 48.0303 255.99 48.0303C247.516 48.0303 239.193 50.2765 231.87 54.54L79.89 143C75.0609 145.814 71.053 149.843 68.2652 154.687C65.4773 159.531 64.0068 165.021 64 170.61V341.37C64.0033 346.962 65.4722 352.456 68.2602 357.304C71.0482 362.152 75.058 366.185 79.89 369L231.89 457.46C239.215 461.718 247.537 463.96 256.01 463.96C264.483 463.96 272.805 461.718 280.13 457.46L432.13 369C436.958 366.182 440.964 362.148 443.748 357.301C446.533 352.453 447.999 346.96 448 341.37Z"
-            stroke="currentColor"
-            stroke-width="32"
-            stroke-linecap="round"
-            stroke-linejoin="round"
-          />
-        </svg>
-      </n-icon>
-    </template>
-  </n-button>
+    <input type="hidden" name="parameters" :value="parameters">
+    <n-button
+      class="edit-button"
+      text
+      :size="size"
+      attr-type="submit"
+      depth="3"
+    >
+      <template #icon>
+        <n-icon>
+          <svg
+            width="512"
+            height="512"
+            viewBox="0 0 512 512"
+            fill="none"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M69 153.99L256 263.99M256 263.99L443 153.99M256 263.99V463.99M448 341.37V170.61C447.993 165.021 446.523 159.531 443.735 154.687C440.947 149.843 436.939 145.814 432.11 143L280.11 54.54C272.787 50.2765 264.464 48.0303 255.99 48.0303C247.516 48.0303 239.193 50.2765 231.87 54.54L79.89 143C75.0609 145.814 71.053 149.843 68.2652 154.687C65.4773 159.531 64.0068 165.021 64 170.61V341.37C64.0033 346.962 65.4722 352.456 68.2602 357.304C71.0482 362.152 75.058 366.185 79.89 369L231.89 457.46C239.215 461.718 247.537 463.96 256.01 463.96C264.483 463.96 272.805 461.718 280.13 457.46L432.13 369C436.958 366.182 440.964 362.148 443.748 357.301C446.533 352.453 447.999 346.96 448 341.37Z"
+              stroke="currentColor"
+              stroke-width="32"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+            />
+          </svg>
+        </n-icon>
+      </template>
+    </n-button>
+  </form>
 </template>
 
 <script>
@@ -40,18 +48,7 @@ export default defineComponent({
   },
   setup (props) {
     return {
-      handleClick () {
-        const div = document.createElement('div')
-        const parameters = getCodeSandboxParams(props.code)
-        div.style.display = 'none'
-        div.innerHTML = `<form action="https://codesandbox.io/api/v1/sandboxes/define" method="POST" target="_blank">
-  <input type="hidden" name="parameters" value="${parameters}" />
-  <input type="submit" value="Open in sandbox" />
-</form>`
-        document.body.appendChild(div)
-        div.firstElementChild.submit()
-        document.body.removeChild(div)
-      }
+      parameters: getCodeSandboxParams(props.code)
     }
   }
 })

--- a/demo/utils/EditOnGithubButton.vue
+++ b/demo/utils/EditOnGithubButton.vue
@@ -3,7 +3,9 @@
     class="edit-button"
     text
     :size="size"
-    @click="handleClick"
+    tag="a"
+    :href="url"
+    target="_blank"
     :depth="depth"
   >
     <template #icon>
@@ -16,7 +18,7 @@
 
 <script>
 import EditIcon from '@vicons/fluent/Compose16Regular.js'
-import { treeUrl } from './github-url'
+import { blobUrl } from './github-url'
 
 export default {
   name: 'EditOnGithubButton',
@@ -34,9 +36,7 @@ export default {
   },
   setup (props) {
     return {
-      handleClick () {
-        window.open(treeUrl + props.relativeUrl, '_blank')
-      }
+      url: blobUrl + props.relativeUrl
     }
   }
 }

--- a/demo/utils/github-url.js
+++ b/demo/utils/github-url.js
@@ -1,2 +1,2 @@
 export const repoUrl = 'https://github.com/TuSimple/naive-ui'
-export const treeUrl = 'https://github.com/TuSimple/naive-ui/tree/main/'
+export const blobUrl = repoUrl + '/blob/main/'


### PR DESCRIPTION
<!--
!!! Please read the following content if this is your first pull request !!!

1. If you are working on docs, please set `docs` branch as the target branch.
2. If you are working on bug fixes or new features, please set `main` branch as the target branch.

For people who are working on 2, please add changelog to `CHANGELOG.zh-CN.md` & `CHANGELOG.en-US.md` in the PR. You need to add changelog to both files. You can use English in both file. The develop team will translate it later.

About docs & changelog's format and other tips, see in `CONTRIBUTING.md`.
-->
<!--
!!! 如果这是你第一次提交 PR，请阅读下面的内容 !!!

1. 如果你在修改文档，请提交到 `docs` 分支
2. 如果你在修复 Bug 或者开发新的特性，请提交到 `main` 分支

对于进行工作 2 的人，请在 `CHANGELOG.zh-CN.md` & `CHANGELOG.en-US.md` 中添加变更日志，你需要在两个文件中都添加变更日志。你可以只使用中文，开发团队会在之后进行翻译。

关于文档和变更日志的格式以及其他的帮助信息，请参考 `CONTRIBUTING.md`。
-->

Refactor `<EditOnGithubButton>` and `<EditInCodeSandboxButton>` to use native `<a>` and `<form>` elements.

Native elements retain expected functionalities and accessibility. A good read about this: [Stop breaking links with JavaScript](https://blog.matsu.io/stop-breaking-links-with-javascript)