### PR TITLE
feat(internal):`base-clear` uses `n` as CSS vars prefix

### DIFF
--- a/CHANGELOG.en-US.md
+++ b/CHANGELOG.en-US.md
@@ -5,6 +5,7 @@
 ### Feats
 
 - Add `n-avatar-group`.
+- `base-clear` uses `n` as CSS vars prefix.
 - `n-popconfirm` uses `n` as CSS vars prefix.
 - `n-gradient-text` uses `n` as CSS vars prefix.
 - `n-form` uses `n` as CSS vars prefix.

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -5,6 +5,7 @@
 ### Feats
 
 - 新增 `n-avatar-group`
+- `base-clear` 的 CSS 变量使用 `n` 作为前缀
 - `n-popconfirm` 的 CSS 变量使用 `n` 作为前缀
 - `n-gradient-text` 的 CSS 变量使用 `n` 作为前缀
 - `n-form` 的 CSS 变量使用 `n` 作为前缀

--- a/src/_internal/clear/src/styles/index.cssr.ts
+++ b/src/_internal/clear/src/styles/index.cssr.ts
@@ -2,11 +2,11 @@ import { cB, c, cE } from '../../../../_utils/cssr'
 import createIconSwitchTransition from '../../../../_styles/transitions/icon-switch.cssr'
 
 // vars:
-// --bezier
-// --clear-color
-// --clear-size
-// --clear-color-hover
-// --clear-color-pressed
+// --n-bezier
+// --n-clear-color
+// --n-clear-size
+// --n-clear-color-hover
+// --n-clear-color-pressed
 export default cB('base-clear', `
   flex-shrink: 0;
   height: 1em;
@@ -15,16 +15,16 @@ export default cB('base-clear', `
 `, [
   c('>', [
     cE('clear', `
-      font-size: var(--clear-size);
+      font-size: var(--n-clear-size);
       cursor: pointer;
-      color: var(--clear-color);
-      transition: color .3s var(--bezier);
+      color: var(--n-clear-color);
+      transition: color .3s var(--n-bezier);
     `, [
       c('&:hover', `
-        color: var(--clear-color-hover)!important;
+        color: var(--n-clear-color-hover)!important;
       `),
       c('&:active', `
-        color: var(--clear-color-pressed)!important;
+        color: var(--n-clear-color-pressed)!important;
       `)
     ]),
     cE('placeholder', `


### PR DESCRIPTION
<!--
!!! Please read the following content if this is your first pull request !!!

1. If you are working on docs, please set `docs` branch as the target branch.
2. If you are working on bug fixes or new features, please set `main` branch as the target branch.

For people who are working on 2, please add changelog to `CHANGELOG.zh-CN.md` & `CHANGELOG.en-US.md` in the PR. You need to add changelog to both files. You can use English in both file. The develop team will translate it later.

About docs & changelog's format and other tips, see in `CONTRIBUTING.md`.
-->
<!--
!!! 如果这是你第一次提交 PR，请阅读下面的内容 !!!

1. 如果你在修改文档，请提交到 `docs` 分支
2. 如果你在修复 Bug 或者开发新的特性，请提交到 `main` 分支

对于进行工作 2 的人，请在 `CHANGELOG.zh-CN.md` & `CHANGELOG.en-US.md` 中添加变更日志，你需要在两个文件中都添加变更日志。你可以只使用中文，开发团队会在之后进行翻译。

关于文档和变更日志的格式以及其他的帮助信息，请参考 `CONTRIBUTING.md`。
-->
