### PR TITLE
feat(internal):`base-close` uses `n` as CSS vars prefix

### DIFF
--- a/CHANGELOG.en-US.md
+++ b/CHANGELOG.en-US.md
@@ -5,6 +5,7 @@
 ### Feats
 
 - Add `n-avatar-group`.
+- `base-close` uses `n` as CSS vars prefix.
 - `n-popconfirm` uses `n` as CSS vars prefix.
 - `n-gradient-text` uses `n` as CSS vars prefix.
 - `n-form` uses `n` as CSS vars prefix.

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -5,6 +5,7 @@
 ### Feats
 
 - 新增 `n-avatar-group`
+- `base-close` 的 CSS 变量使用 `n` 作为前缀
 - `n-popconfirm` 的 CSS 变量使用 `n` 作为前缀
 - `n-gradient-text` 的 CSS 变量使用 `n` 作为前缀
 - `n-form` 的 CSS 变量使用 `n` 作为前缀

--- a/src/_internal/close/src/styles/index.cssr.ts
+++ b/src/_internal/close/src/styles/index.cssr.ts
@@ -1,24 +1,22 @@
 import { cB, cM, c } from '../../../../_utils/cssr'
 
-// Note: non-prefixed color should be removed after css vars prefix migration
-
 // vars:
-// --close-color
-// --close-color-hover
-// --close-color-pressed
-// --close-color-disabled
+// --n-close-color
+// --n-close-color-hover
+// --n-close-color-pressed
+// --n-close-color-disabled
 export default cB('base-close', `
   cursor: pointer;
-  color: var(--close-color, var(--n-close-color));
+  color: var(--n-close-color);
 `, [
   c('&:hover', {
-    color: 'var(--close-color-hover, var(--n-close-color))'
+    color: 'var(--n-close-color-hover)'
   }),
   c('&:active', {
-    color: 'var(--close-color-pressed, var(--n-close-color-pressed))'
+    color: 'var(--n-close-color-pressed)'
   }),
   cM('disabled', {
     cursor: 'not-allowed!important',
-    color: 'var(--close-color-disabled, var(--n-close-color-disabled))'
+    color: 'var(--n-close-color-disabled)'
   })
 ])


### PR DESCRIPTION
<!--
!!! Please read the following content if this is your first pull request !!!

1. If you are working on docs, please set `docs` branch as the target branch.
2. If you are working on bug fixes or new features, please set `main` branch as the target branch.

For people who are working on 2, please add changelog to `CHANGELOG.zh-CN.md` & `CHANGELOG.en-US.md` in the PR. You need to add changelog to both files. You can use English in both file. The develop team will translate it later.

About docs & changelog's format and other tips, see in `CONTRIBUTING.md`.
-->
<!--
!!! 如果这是你第一次提交 PR，请阅读下面的内容 !!!

1. 如果你在修改文档，请提交到 `docs` 分支
2. 如果你在修复 Bug 或者开发新的特性，请提交到 `main` 分支

对于进行工作 2 的人，请在 `CHANGELOG.zh-CN.md` & `CHANGELOG.en-US.md` 中添加变更日志，你需要在两个文件中都添加变更日志。你可以只使用中文，开发团队会在之后进行翻译。

关于文档和变更日志的格式以及其他的帮助信息，请参考 `CONTRIBUTING.md`。
-->
