### PR TITLE
fix: allow Document type for listenTo prop

### DIFF
--- a/CHANGELOG.en-US.md
+++ b/CHANGELOG.en-US.md
@@ -12,6 +12,7 @@
 - Fix `n-upload` doesn't allow 2xx status code except 200.
 - Fix `n-form` when `validate` use `validateCallback`, cannot call Promise method.
 - Fix `n-input-number` input integer end with 0 cannot update, closes [#2115](https://github.com/TuSimple/naive-ui/issues/2115).
+- Fix `n-back-top` allow document to be passed to `listen-to` prop.
 
 ### Feats
 

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -12,6 +12,7 @@
 - 修复 `n-upload` 不允许 200 之外的 2xx 响应状态码
 - 修复 `n-form` 当 `validate` 使用了 `validateCallback` 时调用 Promise 方法无效
 - 修复 `n-input-number` 输入以 0 结尾的整数不更新，关闭 [#2115](https://github.com/TuSimple/naive-ui/issues/2115)
+- Fix `n-back-top` allow document to be passed to `listen-to` prop.
 
 ### Feats
 

--- a/src/back-top/src/BackTop.tsx
+++ b/src/back-top/src/BackTop.tsx
@@ -49,7 +49,7 @@ const backTopProps = {
     default: 180
   },
   listenTo: [String, Object, Function] as PropType<
-  string | HTMLElement | (() => HTMLElement)
+  string | HTMLElement | Document | (() => HTMLElement | Document)
   >,
   'onUpdate:show': {
     type: Function,


### PR DESCRIPTION
<!--
!!! Please read the following content if this is your first pull request !!!

1. If you are working on docs, please set `docs` branch as the target branch.
2. If you are working on bug fixes or new features, please set `main` branch as the target branch.

For people who are working on 2, please add changelog to `CHANGELOG.zh-CN.md` & `CHANGELOG.en-US.md` in the PR. You need to add changelog to both files. You can use English in both file. The develop team will translate it later.

About docs & changelog's format and other tips, see in `CONTRIBUTING.md`.
-->
<!--
!!! 如果这是你第一次提交 PR，请阅读下面的内容 !!!

1. 如果你在修改文档，请提交到 `docs` 分支
2. 如果你在修复 Bug 或者开发新的特性，请提交到 `main` 分支

对于进行工作 2 的人，请在 `CHANGELOG.zh-CN.md` & `CHANGELOG.en-US.md` 中添加变更日志，你需要在两个文件中都添加变更日志。你可以只使用中文，开发团队会在之后进行翻译。

关于文档和变更日志的格式以及其他的帮助信息，请参考 `CONTRIBUTING.md`。
-->

This is just about the type of the prop since it was not yet supported. Though, the code already handles it, e.g. https://github.com/TuSimple/naive-ui/blob/main/src/back-top/src/BackTop.tsx#L177