### PR TITLE
feat: add `for` prop to FormItem

### DIFF
--- a/CHANGELOG.en-US.md
+++ b/CHANGELOG.en-US.md
@@ -81,6 +81,7 @@
 - `n-carousel` adds `on-update:current-index` prop.
 - `n-carousel` adds `arrow` slot.
 - `n-carousel` adds `dots` slot.
+- `n-form-item` adds `for` prop.
 
 ## 2.23.2 (2021-12-29)
 

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -81,6 +81,7 @@
 - `n-carousel` 新增 `on-update:current-index` 属性
 - `n-carousel` 新增 `arrow` slot
 - `n-carousel` 新增 `dots` slot
+- `n-form-item` adds `for` prop.
 
 ## 2.23.2 (2021-12-29)
 

--- a/src/form/src/FormItem.tsx
+++ b/src/form/src/FormItem.tsx
@@ -79,7 +79,7 @@ export const formItemProps = {
     type: Boolean as PropType<boolean | undefined>,
     default: undefined
   },
-  for: String,
+  for: String
 } as const
 
 export type FormItemSetupProps = ExtractPropTypes<typeof formItemProps>

--- a/src/form/src/FormItem.tsx
+++ b/src/form/src/FormItem.tsx
@@ -78,7 +78,8 @@ export const formItemProps = {
   showLabel: {
     type: Boolean as PropType<boolean | undefined>,
     default: undefined
-  }
+  },
+  for: String,
 } as const
 
 export type FormItemSetupProps = ExtractPropTypes<typeof formItemProps>
@@ -432,6 +433,7 @@ export default defineComponent({
       >
         {mergedShowLabel && (this.label || $slots.label) ? (
           <label
+            for={this.for}
             class={`${mergedClsPrefix}-form-item-label`}
             style={this.mergedLabelStyle as any}
             ref="labelElementRef"

--- a/src/form/tests/Form.spec.tsx
+++ b/src/form/tests/Form.spec.tsx
@@ -195,4 +195,25 @@ describe('n-form', () => {
     ).toBe(true)
     expect(wrapper.findAll('.n-form-item-label').length).toBe(0)
   })
+
+  it('includes `for` attribute in label', () => {
+    const wrapper = mount(() => (
+      <NForm>
+        {{
+          default: () => {
+            return (
+              <NFormItem label="star kirby" for="input">
+                {{
+                  default: () => <NInput />
+                }}
+              </NFormItem>
+            )
+          }
+        }}
+      </NForm>
+    ))
+    expect(
+      wrapper.find('.n-form-item-label').attributes('for')
+    ).toBe('input')
+  })
 })


### PR DESCRIPTION
<!--
!!! Please read the following content if this is your first pull request !!!

1. If you are working on docs, please set `docs` branch as the target branch.
2. If you are working on bug fixes or new features, please set `main` branch as the target branch.

For people who are working on 2, please add changelog to `CHANGELOG.zh-CN.md` & `CHANGELOG.en-US.md` in the PR. You need to add changelog to both files. You can use English in both file. The develop team will translate it later.

About docs & changelog's format and other tips, see in `CONTRIBUTING.md`.
-->
<!--
!!! 如果这是你第一次提交 PR，请阅读下面的内容 !!!

1. 如果你在修改文档，请提交到 `docs` 分支
2. 如果你在修复 Bug 或者开发新的特性，请提交到 `main` 分支

对于进行工作 2 的人，请在 `CHANGELOG.zh-CN.md` & `CHANGELOG.en-US.md` 中添加变更日志，你需要在两个文件中都添加变更日志。你可以只使用中文，开发团队会在之后进行翻译。

关于文档和变更日志的格式以及其他的帮助信息，请参考 `CONTRIBUTING.md`。
-->

This PR adds a `for` prop to the `FormItem` component to specify which form element the label is bound to.