### PR TITLE
fix: handle empty string and single mode other than RGB in `ColorPicker`

### DIFF
--- a/src/color-picker/src/ColorPicker.tsx
+++ b/src/color-picker/src/ColorPicker.tsx
@@ -82,7 +82,7 @@ export const colorPickerPanelProps = {
   modes: {
     type: Array as PropType<ColorPickerMode[]>,
     // no hsva by default since browser doesn't support it
-    default: ['rgb', 'hex', 'hsl']
+    default: () => ['rgb', 'hex', 'hsl']
   },
   to: useAdjustedTo.propTo,
   showAlpha: {
@@ -167,8 +167,9 @@ export default defineComponent({
 
     const valueModeRef = computed(() => getModeFromValue(mergedValueRef.value))
 
+    const { modes } = props
     const displayedModeRef = ref<ColorPickerMode>(
-      getModeFromValue(mergedValueRef.value) || 'rgb'
+      getModeFromValue(mergedValueRef.value) || modes[0] || 'rgb'
     )
 
     function handleUpdateDisplayedMode (): void {

--- a/src/color-picker/src/ColorPicker.tsx
+++ b/src/color-picker/src/ColorPicker.tsx
@@ -169,7 +169,7 @@ export default defineComponent({
 
     const { modes } = props
     const displayedModeRef = ref<ColorPickerMode>(
-      getModeFromValue(mergedValueRef.value) || modes[0] || 'rgb'
+      getModeFromValue(mergedValueRef.value) || modes[0] || 'rgb'
     )
 
     function handleUpdateDisplayedMode (): void {

--- a/src/color-picker/tests/ColorPicker.spec.tsx
+++ b/src/color-picker/tests/ColorPicker.spec.tsx
@@ -44,6 +44,23 @@ describe('n-color-picker', () => {
       expect(modeDom?.textContent).toEqual('HSLA')
       wrapper.unmount()
     })
+    it('single mode with empty string', async () => {
+      const wrapper = mount(NColorPicker, {
+        attachTo: document.body,
+        props: {
+          value: '',
+          modes: ['hsl']
+        }
+      })
+      await wrapper.find('.n-color-picker-trigger').trigger('click')
+      expect(document.querySelector('.n-color-picker-panel')).not.toEqual(null)
+      const modeDom = document.querySelector('.n-color-picker-input__mode')
+      expect(modeDom?.textContent).toEqual('HSLA')
+      ;(modeDom as HTMLElement).click()
+      await nextTick()
+      expect(modeDom?.textContent).toEqual('HSLA')
+      wrapper.unmount()
+    })
     it('has correct default value', () => {
       const input: Array<{ modes: ColorPickerMode[], value: string }> = [
         {


### PR DESCRIPTION
<!--
!!! Please read the following content if this is your first pull request !!!

1. If you are working on docs, please set `docs` branch as the target branch.
2. If you are working on bug fixes or new features, please set `main` branch as the target branch.

For people who are working on 2, please add changelog to `CHANGELOG.zh-CN.md` & `CHANGELOG.en-US.md` in the PR. You need to add changelog to both files. You can use English in both file. The develop team will translate it later.

About docs & changelog's format and other tips, see in `CONTRIBUTING.md`.
-->
<!--
!!! 如果这是你第一次提交 PR，请阅读下面的内容 !!!

1. 如果你在修改文档，请提交到 `docs` 分支
2. 如果你在修复 Bug 或者开发新的特性，请提交到 `main` 分支

对于进行工作 2 的人，请在 `CHANGELOG.zh-CN.md` & `CHANGELOG.en-US.md` 中添加变更日志，你需要在两个文件中都添加变更日志。你可以只使用中文，开发团队会在之后进行翻译。

关于文档和变更日志的格式以及其他的帮助信息，请参考 `CONTRIBUTING.md`。
-->

I noticed that the single mode (other than RGB) of the `ColorPicker` does not work as soon as you use an empty string and instead the default RGB picker will be offered.