### PR TITLE
feat: expose useTheme and lightTheme

### DIFF
--- a/src/composables/index.ts
+++ b/src/composables/index.ts
@@ -1,1 +1,2 @@
 export { useThemeVars } from './use-theme-vars'
+export { useTheme } from './../_mixins/use-theme.ts'

--- a/src/composables/index.ts
+++ b/src/composables/index.ts
@@ -1,2 +1,2 @@
 export { useThemeVars } from './use-theme-vars'
-export { useTheme } from './../_mixins/use-theme.ts'
+export { default as useTheme } from './../_mixins/use-theme'

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,7 +11,7 @@ export * from './composables'
 // component themes
 export * from './styles'
 // composed global theme, createTheme from component themes util
-export { darkTheme, createTheme } from './themes'
+export { darkTheme, lightTheme, createTheme } from './themes'
 
 export { c, cE, cM, cB, cNotM } from './_utils/cssr'
 

--- a/src/themes/index.ts
+++ b/src/themes/index.ts
@@ -1,2 +1,3 @@
 export { darkTheme } from './dark'
+export { lightTheme } from './light'
 export { createTheme } from './utils'

--- a/src/themes/light.ts
+++ b/src/themes/light.ts
@@ -1,5 +1,3 @@
-// The file is for internal usage, do not export it, since all the components
-// have default light theme.
 import { commonLight } from '../_styles/common'
 import { alertLight } from '../alert/styles'
 import { anchorLight } from '../anchor/styles'


### PR DESCRIPTION
<!--
!!! Please read the following content if this is your first pull request !!!

1. If you are working on docs, please set `docs` branch as the target branch.
2. If you are working on bug fixes or new features, please set `main` branch as the target branch.

For people who are working on 2, please add changelog to `CHANGELOG.zh-CN.md` & `CHANGELOG.en-US.md` in the PR. You need to add changelog to both files. You can use English in both file. The develop team will translate it later.

About docs & changelog's format and other tips, see in `CONTRIBUTING.md`.
-->
<!--
!!! 如果这是你第一次提交 PR，请阅读下面的内容 !!!

1. 如果你在修改文档，请提交到 `docs` 分支
2. 如果你在修复 Bug 或者开发新的特性，请提交到 `main` 分支

对于进行工作 2 的人，请在 `CHANGELOG.zh-CN.md` & `CHANGELOG.en-US.md` 中添加变更日志，你需要在两个文件中都添加变更日志。你可以只使用中文，开发团队会在之后进行翻译。

关于文档和变更日志的格式以及其他的帮助信息，请参考 `CONTRIBUTING.md`。
-->

It would be great if the library could expose `useTheme` and `lightTheme` so it is easily possible to write custom components the same way as this library does. 