### PR TITLE
fix: mute types of peer dependency warnings of pnpm

### DIFF
--- a/package.json
+++ b/package.json
@@ -158,5 +158,10 @@
     "ui framework",
     "ui",
     "vue"
-  ]
+  ],
+  "pnpm": {
+    "peerDependencyRules": {
+      "ignoreMissing": ["@babel/core", "postcss", "rollup", "webpack"]
+    }
+  }
 }

--- a/package.json
+++ b/package.json
@@ -161,7 +161,13 @@
   ],
   "pnpm": {
     "peerDependencyRules": {
-      "ignoreMissing": ["@babel/core", "postcss", "rollup", "webpack"]
+      "ignoreMissing": ["@babel/core", "postcss", "rollup", "webpack"],
+      "allowedVersions": {
+        "eslint": "^8.6.0",
+        "eslint-plugin-promise": "^6.0.0",
+        "@typescript-eslint/eslint-plugin": "^5.9.1",
+        "eslint-plugin-vue": "^8.3.0"
+      }
     }
   }
 }


### PR DESCRIPTION
After pnpm releases the version of `v6.26.0`, the warning can be ignored at the config, releases notes: https://github.com/pnpm/pnpm/releases/tag/v6.26.0

Before: 

![image](https://user-images.githubusercontent.com/32598811/149463017-2af746b9-93ab-4647-a871-9f3484168f73.png)


After: 

![image](https://user-images.githubusercontent.com/32598811/149463953-5978bddd-319a-4f23-a0bc-b721b34e762c.png)
