### PR TITLE
feat: export ThemeCommonVars and make type augmentable

### DIFF
--- a/src/composables/use-theme-vars.ts
+++ b/src/composables/use-theme-vars.ts
@@ -2,8 +2,11 @@ import { computed, ComputedRef, inject } from 'vue'
 import { configProviderInjectionKey } from '../config-provider/src/ConfigProvider'
 import { commonLight } from '../_styles/common'
 import type { ThemeCommonVars } from '../_styles/common'
+import type { ThemeCommonVarsExtension } from '../config-provider'
 
-export function useThemeVars (): ComputedRef<ThemeCommonVars> {
+export function useThemeVars (): ComputedRef<
+ThemeCommonVars & ThemeCommonVarsExtension
+> {
   const configProviderInjection = inject(configProviderInjectionKey, null)
   return computed(() => {
     if (configProviderInjection === null) return commonLight

--- a/src/config-provider/src/interface.ts
+++ b/src/config-provider/src/interface.ts
@@ -4,6 +4,7 @@ import type { GlobalThemeWithoutCommon } from './internal-interface'
 
 export { ThemeCommonVars }
 
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
 export interface ThemeCommonVarsExtension {}
 
 export interface GlobalTheme extends GlobalThemeWithoutCommon {

--- a/src/config-provider/src/interface.ts
+++ b/src/config-provider/src/interface.ts
@@ -2,12 +2,16 @@ import type { ThemeCommonVars } from '../../_styles/common'
 import type { ExtractThemeOverrides } from '../../_mixins/use-theme'
 import type { GlobalThemeWithoutCommon } from './internal-interface'
 
+export { ThemeCommonVars }
+
+export interface ThemeCommonVarsExtension {}
+
 export interface GlobalTheme extends GlobalThemeWithoutCommon {
   common?: ThemeCommonVars
 }
 
 export type GlobalThemeOverrides = {
-  common?: Partial<ThemeCommonVars>
+  common?: Partial<ThemeCommonVars & ThemeCommonVarsExtension>
 } & {
   [key in keyof GlobalThemeWithoutCommon]?: ExtractThemeOverrides<
   GlobalThemeWithoutCommon[key]


### PR DESCRIPTION
It would be cool to make the theme type augmentable so we can use extend the theme with custom variables `useTheme`. An extension could look like this:
```typescript
import 'naive-ui';

declare module 'naive-ui' {
  export interface ThemeCommonVarsExtension {
      primaryColorActive: string
  }
}
```