### PR TITLE
Update custom-request.demo.md

### DIFF
--- a/src/upload/demos/enUS/custom-request.demo.md
+++ b/src/upload/demos/enUS/custom-request.demo.md
@@ -42,7 +42,7 @@ export default defineComponent({
           formData.append(key, data[key])
         })
       }
-      formData.append(file.name, file)
+      formData.append(file.name, file.file)
       axios
         .post(action, formData, {
           withCredentials,


### PR DESCRIPTION
Hi, there is an incorrect usage at line 45: we should pass the "file.file", the binary prop, instead of the `file` param that comes from `customRequest`. Otherwise we will find axios actually sends string "[object, Object]" in the Form Data, not the binary.

<!--
!!! Please read the following content if this is your first pull request !!!

1. If you are working on docs, please set `docs` branch as the target branch.
2. If you are working on bug fixes or new features, please set `main` branch as the target branch.

For people who are working on 2, please add changelog to `CHANGELOG.zh-CN.md` & `CHANGELOG.en-US.md` in the PR. You need to add changelog to both files. You can use English in both file. The develop team will translate it later.

About docs & changelog's format and other tips, see in `CONTRIBUTING.md`.
-->
<!--
!!! 如果这是你第一次提交 PR，请阅读下面的内容 !!!

1. 如果你在修改文档，请提交到 `docs` 分支
2. 如果你在修复 Bug 或者开发新的特性，请提交到 `main` 分支

对于进行工作 2 的人，请在 `CHANGELOG.zh-CN.md` & `CHANGELOG.en-US.md` 中添加变更日志，你需要在两个文件中都添加变更日志。你可以只使用中文，开发团队会在之后进行翻译。

关于文档和变更日志的格式以及其他的帮助信息，请参考 `CONTRIBUTING.md`。
-->
