### PR TITLE
docs(NDynamicTag): update n dynamic tag docs, adding input props 

### DIFF
--- a/src/dynamic-tags/demos/enUS/index.demo-entry.md
+++ b/src/dynamic-tags/demos/enUS/index.demo-entry.md
@@ -22,6 +22,7 @@ slot
 | default-value | `string[]` | `[]` | Default value. |
 | disabled | `boolean` | `false` | Whether the tag is disabled. |
 | input-style | `string \| Object` | `undefined` | Customize the style of the input. |
+| input-props | `HTMLInputAttributes` | `undefined` | The attributes of the input element within the dynamic tag. |
 | max | `number` | `undefined` | Maximum number of tags. |
 | round | `boolean` | `false` | Whether the tag has rounded corners. |
 | size | `'small' \| 'medium' \| 'large'` | `'medium'` | Size of the tag. |

--- a/src/dynamic-tags/demos/zhCN/index.demo-entry.md
+++ b/src/dynamic-tags/demos/zhCN/index.demo-entry.md
@@ -22,6 +22,7 @@ slot
 | default-value | `string[]` | `[]` | 非受控模式下的默认值 |
 | disabled | `boolean` | `false` | 是否禁用 |
 | input-style | `string \| Object` | `undefined` | 自定义输入框的样式 |
+| input-props | `HTMLInputAttributes` | `undefined` | 自动填充中 input 元素的属性 |
 | max | `number` | `undefined` | tag 的最大数量 |
 | round | `boolean` | `false` | 是否圆角 |
 | size | `'small' \| 'medium' \| 'large'` | `'medium'` | 尺寸大小 |


### PR DESCRIPTION
Accompanying pr for the documentations to be in line with the update of NDynamicTag having the input-props prop added to it's functionality. PR can be found here: [#2263](https://github.com/TuSimple/naive-ui/pull/2263).