### PR TITLE
feat: add `defaultValidationStatus` prop to `Form`

### DIFF
--- a/CHANGELOG.en-US.md
+++ b/CHANGELOG.en-US.md
@@ -19,6 +19,7 @@
 - `n-time-picker` adds `placement` prop.
 - `n-tree-select` adds `placement` prop.
 - `n-card` adds `header-extra-style` prop.
+- `n-form` adds `default-validation-status` prop.
 
 ### Fixes
 

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -19,6 +19,7 @@
 - `n-time-picker` 新增 `placement` 属性
 - `n-tree-select` 新增 `placement` 属性
 - `n-card` 新增 `header-extra-style` 属性
+- `n-form` adds `default-validation-status` prop
 
 ### Fixes
 

--- a/src/form/demos/enUS/index.demo-entry.md
+++ b/src/form/demos/enUS/index.demo-entry.md
@@ -25,6 +25,7 @@ partially-apply-rules
 
 | Name | Type | Default | Description | Version |
 | --- | --- | --- | --- | --- |
+| default-validation-status | `'error' \| 'success' \| 'warning'` | `'error'` | The default validation status of the form if a rule-based validation fails. |  |
 | disabled | `boolean` | `false` | Whether to disable the form. |  |
 | inline | `boolean` | `false` | Whether to display as an inline form. |  |
 | label-width | `number \| string \| 'auto'` | `undefined` | The width of label. Particularly useful when `label-placement` is set to `'left'`,`'auto'` means label width will be auto adjusted. |  |

--- a/src/form/demos/zhCN/index.demo-entry.md
+++ b/src/form/demos/zhCN/index.demo-entry.md
@@ -27,6 +27,7 @@ partially-apply-rules
 
 | 名称 | 类型 | 默认值 | 说明 | 版本 |
 | --- | --- | --- | --- | --- |
+| default-validation-status | `'error' \| 'success' \| 'warning'` | `'error'` | The default validation status of the form if a rule-based validation fails. |  |
 | disabled | `boolean` | `false` | 是否禁用 |  |
 | inline | `boolean` | `false` | 是否展示为行内表单 |  |
 | label-width | `number \| string \| 'auto'` | `undefined` | 标签的宽度，在 `label-placement` 是 `'left'` 的时候可能会有用，`'auto'` 意味着 label width 会被自动调整 |  |

--- a/src/form/src/Form.tsx
+++ b/src/form/src/Form.tsx
@@ -50,6 +50,10 @@ const formProps = {
     type: Boolean,
     default: true
   },
+  defaultValidationStatus: {
+    type: String as PropType<'error' | 'warning' | 'success'>,
+    default: 'error'
+  },
   onSubmit: {
     type: Function as PropType<(e: Event) => void>,
     default: (e: Event) => e.preventDefault()

--- a/src/form/src/utils.ts
+++ b/src/form/src/utils.ts
@@ -78,7 +78,7 @@ export function formItemMisc (props: FormItemSetupProps) {
   const mergedValidationStatusRef = computed(() => {
     const { validationStatus } = props
     if (validationStatus !== undefined) return validationStatus
-    if (validationErroredRef.value) return 'error'
+    if (validationErroredRef.value) { return NForm?.props.defaultValidationStatus || 'error' }
     return undefined
   })
   const mergedShowFeedbackRef = computed(() => {


### PR DESCRIPTION
This PR will add a new `defaultValidationStatus` prop to `Form` which for example let's you change the validation status to warnings. In my case I would like to show client based validations as warnings and if the user anyway clicks on submit it should be displayed as errors.