### PR TITLE
fix(locale): locale frFR missing translation for Image

### DIFF
--- a/CHANGELOG.en-US.md
+++ b/CHANGELOG.en-US.md
@@ -24,6 +24,7 @@
 ### i18n
 
 - Add skSK locale.
+- Fix frFR locale.
 
 ## 2.25.2
 

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -24,6 +24,7 @@
 ### i18n
 
 - 新增 skSK locale
+- 完善 frFR locale
 
 ## 2.25.2
 

--- a/src/locales/common/frFR.ts
+++ b/src/locales/common/frFR.ts
@@ -90,7 +90,7 @@ const frFR: NLocale = {
     create: 'Créer'
   },
   ThemeEditor: {
-    title: 'Editeur de thème',
+    title: 'Éditeur de thème',
     clearAllVars: 'Effacer toutes les variables',
     clearSearch: 'Effacer la recherche',
     filterCompName: 'Filtrer par nom de composant',
@@ -99,15 +99,14 @@ const frFR: NLocale = {
     export: 'Exporter',
     restore: 'Réinitialiser'
   },
-  // TODO: translation
   Image: {
-    tipPrevious: 'Previous picture (←)',
-    tipNext: 'Next picture (→)',
-    tipCounterclockwise: 'Counterclockwise',
-    tipClockwise: 'Clockwise',
-    tipZoomOut: 'Zoom out',
-    tipZoomIn: 'Zoom in',
-    tipClose: 'Close (Esc)'
+    tipPrevious: 'Image précédente (←)',
+    tipNext: 'Image suivante (→)',
+    tipCounterclockwise: 'Sens antihoraire',
+    tipClockwise: 'Sens horaire',
+    tipZoomOut: 'Dézoomer',
+    tipZoomIn: 'Zoomer',
+    tipClose: 'Fermer (Échap.)'
   }
 }
 


### PR DESCRIPTION
Fix locale frFR missing translation for `Image`.

Also improved an existing translation on `ThemeEditor.title` (very minor change).