### PR TITLE
docs(data-table): fix type of `row-class-name`

### DIFF
--- a/src/data-table/demos/enUS/custom-style.demo.md
+++ b/src/data-table/demos/enUS/custom-style.demo.md
@@ -60,7 +60,7 @@ export default defineComponent({
         if (row.age > 32) {
           return 'too-old'
         }
-        return null
+        return ''
       }
     }
   }

--- a/src/data-table/demos/enUS/index.demo-entry.md
+++ b/src/data-table/demos/enUS/index.demo-entry.md
@@ -69,7 +69,7 @@ context-menu.vue
 | min-height | `number \| string` | `undefined` | The min-height of the table content. Can be a CSS value. |
 | pagination | `false \| object` | `false` | See [Pagination props](pagination#Pagination-Props) |
 | remote | `boolean` | `false` | If data-table do automatic paging. You may set it to `false` in async usage. |
-| row-class-name | `string \| (rowData: object, rowIndex : number) => string \| object` | `undefined` | Class name of each row. |
+| row-class-name | `string \| (rowData: object, rowIndex : number) => string` | `undefined` | Class name of each row. |
 | row-key | `(rowData: object) => (number \| string)` | `undefined` | Generate the key of the row by row data (if you don't want to set the key). |
 | row-props | `(rowData: object, rowIndex : number) => object` | `undefined` | Customize row attributes. |
 | scroll-x | `number \| string` | `undefined` | If columns are horizontal fixed, scroll-x need to be set. |

--- a/src/data-table/demos/zhCN/custom-style.demo.md
+++ b/src/data-table/demos/zhCN/custom-style.demo.md
@@ -60,7 +60,7 @@ export default defineComponent({
         if (row.age > 32) {
           return 'too-old'
         }
-        return null
+        return ''
       }
     }
   }

--- a/src/data-table/demos/zhCN/index.demo-entry.md
+++ b/src/data-table/demos/zhCN/index.demo-entry.md
@@ -73,7 +73,7 @@ height-debug
 | min-height | `number \| string` | `undefined` | 表格内容的最低高度，可以是 CSS 属性值 |
 | pagination | `false \| object` | `false` | 属性参考 [Pagination props](pagination#Pagination-Props) |
 | remote | `boolean` | `false` | 表格是否自动分页数据，在异步的状况下你可能需要把它设为 `true` |
-| row-class-name | `string \| (rowData: object, index : number) => string \| object` | `undefined` | 每一行上的类名 |
+| row-class-name | `string \| (rowData: object, index : number) => string` | `undefined` | 每一行上的类名 |
 | row-key | `(rowData: object) => (number \| string)` | `undefined` | 通过行数据创建行的 key（如果你不想给每一行加上 key） |
 | row-props | `(rowData: object, rowIndex : number) => object` | `undefined` | 自定义行属性 |
 | scroll-x | `number \| string` | `undefined` | 表格内容的横向宽度，如果列被水平固定了，则需要设定它 |


### PR DESCRIPTION
Prop `row-class-name` was typed by interface `CreateRowClassName` a year ago in commit [42be41d](https://github.com/TuSimple/naive-ui/commit/42be41dc4b1ddff31bd1b8d7f31196ebf401df5a)
Whose `ReturnType` has been narrowed to `string` only

Plus, Vue also suggests using **Empty String** to represent "null" classname in its code example
[Vue - Class and Style Bindings - Binding to Arrays](https://vuejs.org/guide/essentials/class-and-style.html#binding-to-arrays)

Thus, sync up the typing `CreateRowClassName` with docs and demos