### PR TITLE
fix: resolve n-input-number hold click event bug, change firstAddMous…

### DIFF
--- a/src/input-number/src/InputNumber.tsx
+++ b/src/input-number/src/InputNumber.tsx
@@ -366,7 +366,7 @@ export default defineComponent({
       }
       if (addHoldStateIntervalId) {
         window.clearInterval(addHoldStateIntervalId)
-        firstAddMousedownId = null
+        addHoldStateIntervalId = null
       }
     }
     function handleMinusMousedown (): void {


### PR DESCRIPTION
Fixes  [this issue](https://github.com/TuSimple/naive-ui/commit/758eed5d1ef6cfb0c6922c346c9e9908a86f09ad#commitcomment-67173566)

---

Apologies if you're already resolving this, just thought to try and help out. However, should I add the onmouseLeave events for the buttons as I mentioned in the above comment too? (Thought it would be best to create separate prs for this, as I'm not sure this is how you would like it to be implemented on the n-input-number.)
