### PR TITLE
fix(data-picker):make n-date-panel-date fill all area of all demos

### DIFF
--- a/src/date-picker/src/panel/daterange.tsx
+++ b/src/date-picker/src/panel/daterange.tsx
@@ -119,6 +119,7 @@ export default defineComponent({
                 onClick={() => this.handleDateClick(dateItem)}
                 onMouseenter={() => this.handleDateMouseEnter(dateItem)}
               >
+                <div class={`${mergedClsPrefix}-date-panel-date__trigger`} />
                 {dateItem.dateObject.date}
                 {dateItem.isCurrentDate ? (
                   <div class={`${mergedClsPrefix}-date-panel-date__sup`} />

--- a/src/date-picker/src/panel/datetime.tsx
+++ b/src/date-picker/src/panel/datetime.tsx
@@ -133,6 +133,7 @@ export default defineComponent({
                 ]}
                 onClick={() => this.handleDateClick(dateItem)}
               >
+                <div class={`${mergedClsPrefix}-date-panel-date__trigger`} />
                 {dateItem.dateObject.date}
                 {dateItem.isCurrentDate ? (
                   <div class={`${mergedClsPrefix}-date-panel-date__sup`} />

--- a/src/date-picker/src/panel/datetimerange.tsx
+++ b/src/date-picker/src/panel/datetimerange.tsx
@@ -177,6 +177,7 @@ export default defineComponent({
                 onClick={() => this.handleDateClick(dateItem)}
                 onMouseenter={() => this.handleDateMouseEnter(dateItem)}
               >
+                <div class={`${mergedClsPrefix}-date-panel-date__trigger`} />
                 {dateItem.dateObject.date}
                 {dateItem.isCurrentDate ? (
                   <div class={`${mergedClsPrefix}-date-panel-date__sup`} />
@@ -262,6 +263,7 @@ export default defineComponent({
                 onClick={() => this.handleDateClick(dateItem)}
                 onMouseenter={() => this.handleDateMouseEnter(dateItem)}
               >
+                <div class={`${mergedClsPrefix}-date-panel-date__trigger`} />
                 {dateItem.dateObject.date}
                 {dateItem.isCurrentDate ? (
                   <div class={`${mergedClsPrefix}-date-panel-date__sup`} />

--- a/src/dynamic-tags/demos/enUS/slot.demo.vue
+++ b/src/dynamic-tags/demos/enUS/slot.demo.vue
@@ -6,7 +6,7 @@ You can replace a dynamic-tags input or trigger element with another component.
 
 <template>
   <n-dynamic-tags v-model:value="tags">
-    <template #input="{ submit }">
+    <template #input="{ submit, handleInputBlur }">
       <n-auto-complete
         v-model:value="inputValue"
         size="small"
@@ -14,6 +14,7 @@ You can replace a dynamic-tags input or trigger element with another component.
         placeholder="Email"
         :clear-after-select="true"
         @select="submit($event)"
+        @blur="handleInputBlur"
       />
     </template>
     <template #trigger="{ activate, disabled }">

--- a/src/dynamic-tags/demos/zhCN/slot.demo.vue
+++ b/src/dynamic-tags/demos/zhCN/slot.demo.vue
@@ -6,7 +6,7 @@
 
 <template>
   <n-dynamic-tags v-model:value="tags" :max="3">
-    <template #input="{ submit }">
+    <template #input="{ submit, handleInputBlur }">
       <n-auto-complete
         v-model:value="inputValue"
         size="small"
@@ -14,6 +14,7 @@
         placeholder="邮箱"
         :clear-after-select="true"
         @select="submit($event)"
+        @blur="handleInputBlur"
       />
     </template>
     <template #trigger="{ activate, disabled }">

--- a/src/dynamic-tags/src/DynamicTags.tsx
+++ b/src/dynamic-tags/src/DynamicTags.tsx
@@ -87,6 +87,7 @@ export default defineComponent({
       props,
       mergedClsPrefixRef
     )
+    // 为什么要分受控和非受控
     const uncontrolledValueRef = ref(props.defaultValue)
     const controlledValueRef = toRef(props, 'value')
     const mergedValueRef = useMergedState(
@@ -243,7 +244,10 @@ export default defineComponent({
               .concat(
                 showInput ? (
                   $slots.input ? (
-                    $slots.input({ submit: handleInputConfirm })
+                    $slots.input({
+                      submit: handleInputConfirm,
+                      handleInputBlur
+                    })
                   ) : (
                     <NInput
                       placeholder=""


### PR DESCRIPTION
I found that this was not fully resolved.   https://github.com/TuSimple/naive-ui/issues/2547
and this is your commit   https://github.com/TuSimple/naive-ui/commit/ec9546265141bce339f9f45f0dff2d7905d72ba3
It seems that only the first demo was fixed, and others  remain.
Or maybe there are other reasons I don't know about， I am not sure.
https://www.naiveui.com/zh-CN/os-theme/components/date-picker