### PR TITLE
fix(data-picker):make n-date-panel-date fill all area of all demos

### DIFF
--- a/src/date-picker/src/panel/daterange.tsx
+++ b/src/date-picker/src/panel/daterange.tsx
@@ -119,6 +119,7 @@ export default defineComponent({
                 onClick={() => this.handleDateClick(dateItem)}
                 onMouseenter={() => this.handleDateMouseEnter(dateItem)}
               >
+                <div class={`${mergedClsPrefix}-date-panel-date__trigger`} />
                 {dateItem.dateObject.date}
                 {dateItem.isCurrentDate ? (
                   <div class={`${mergedClsPrefix}-date-panel-date__sup`} />

--- a/src/date-picker/src/panel/datetime.tsx
+++ b/src/date-picker/src/panel/datetime.tsx
@@ -133,6 +133,7 @@ export default defineComponent({
                 ]}
                 onClick={() => this.handleDateClick(dateItem)}
               >
+                <div class={`${mergedClsPrefix}-date-panel-date__trigger`} />
                 {dateItem.dateObject.date}
                 {dateItem.isCurrentDate ? (
                   <div class={`${mergedClsPrefix}-date-panel-date__sup`} />

--- a/src/date-picker/src/panel/datetimerange.tsx
+++ b/src/date-picker/src/panel/datetimerange.tsx
@@ -177,6 +177,7 @@ export default defineComponent({
                 onClick={() => this.handleDateClick(dateItem)}
                 onMouseenter={() => this.handleDateMouseEnter(dateItem)}
               >
+                <div class={`${mergedClsPrefix}-date-panel-date__trigger`} />
                 {dateItem.dateObject.date}
                 {dateItem.isCurrentDate ? (
                   <div class={`${mergedClsPrefix}-date-panel-date__sup`} />
@@ -262,6 +263,7 @@ export default defineComponent({
                 onClick={() => this.handleDateClick(dateItem)}
                 onMouseenter={() => this.handleDateMouseEnter(dateItem)}
               >
+                <div class={`${mergedClsPrefix}-date-panel-date__trigger`} />
                 {dateItem.dateObject.date}
                 {dateItem.isCurrentDate ? (
                   <div class={`${mergedClsPrefix}-date-panel-date__sup`} />


### PR DESCRIPTION
I found that this was not fully resolved. https://github.com/TuSimple/naive-ui/issues/2552
and this is your commit https://github.com/TuSimple/naive-ui/commit/ec9546265141bce339f9f45f0dff2d7905d72ba3
It seems that only the first demo was fixed, and others remain.
Or maybe there are other reasons I don't know about， I am not sure.
https://www.naiveui.com/zh-CN/os-theme/components/date-picker
