### PR TITLE
fix(tree-select): cannot delete options whose default-value property …

### DIFF
--- a/CHANGELOG.en-US.md
+++ b/CHANGELOG.en-US.md
@@ -5,6 +5,7 @@
 ### Fixes
 
 - Fix `n-button`'s loading icon shifts.
+- Fix `n-tree-select`s in `multiple` mode cannot delete options whose `default-value` attribute contains parent node
 
 ## 2.26.2
 

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -5,6 +5,7 @@
 ### Fixes
 
 - 修复 `n-button` loading 图标漂移
+- 修复 `n-tree-select` 在 multiple 模式下不能删除 default-value 属性包含父节点的选项
 
 ## 2.26.2
 

--- a/src/tree-select/src/TreeSelect.tsx
+++ b/src/tree-select/src/TreeSelect.tsx
@@ -520,19 +520,27 @@ export default defineComponent({
       // only work for multiple mode
       const { value: mergedValue } = mergedValueRef
       if (Array.isArray(mergedValue)) {
-        const index = mergedValue.findIndex((key) => key === option.value)
+        const { value: treeMate } = dataTreeMateRef
+        const { checkedKeys: checkedKeysValue } = treeMate.getCheckedKeys(
+          mergedValue,
+          {
+            checkStrategy: props.checkStrategy,
+            cascade: mergedCascadeRef.value
+          }
+        )
+        const index = checkedKeysValue.findIndex((key) => key === option.value)
         if (~index) {
           if (props.checkable) {
-            const { checkedKeys } = dataTreeMateRef.value.uncheck(
+            const { checkedKeys } = treeMate.uncheck(
               option.value,
-              mergedValue,
+              checkedKeysValue,
               {
                 cascade: mergedCascadeRef.value
               }
             )
             doUpdateValue(checkedKeys, getOptionsByKeys(checkedKeys))
           } else {
-            const nextValue = Array.from(mergedValue)
+            const nextValue = Array.from(checkedKeysValue)
             nextValue.splice(index, 1)
             doUpdateValue(nextValue, getOptionsByKeys(nextValue))
           }


### PR DESCRIPTION
在所给dome**指定勾选策略**中，发现当`default-value`的值是['Dig It', 'go']时，其父节点`Across The Universe
`也被选中，但是却无法删除它。