### PR TITLE
feat: add `messages` prop to `Form`

### DIFF
--- a/CHANGELOG.en-US.md
+++ b/CHANGELOG.en-US.md
@@ -15,6 +15,7 @@
 - `useDialog` supports `closeOnEsc` prop.
 - `n-data-table` exports `DataTableFilterState` type.
 - `n-data-table` exports `DataTableSortState` type.
+- `n-form` adds `messages` prop.
 
 ## 2.26.3
 

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -15,6 +15,7 @@
 - `useDialog` 支持 `closeOnEsc` 属性
 - `n-data-table` 导出 `DataTableFilterState` 类型
 - `n-data-table` 导出 `DataTableSortState` 类型
+- `n-form` adds `messages` prop.
 
 ## 2.26.3
 

--- a/src/form/demos/enUS/custom-messages.demo.vue
+++ b/src/form/demos/enUS/custom-messages.demo.vue
@@ -1,0 +1,63 @@
+<markdown>
+# Custom messages
+
+You can define custom messages that are used instead of the standard ones.
+</markdown>
+
+<template>
+  <n-form ref="formRef" :model="formValue" :rules="rules" :messages="messages">
+    <n-form-item label="Name" path="user.name">
+      <n-input v-model:value="formValue.user.name" placeholder="Input Name" />
+    </n-form-item>
+    <n-form-item>
+      <n-button @click="handleValidateClick">
+        Validate
+      </n-button>
+    </n-form-item>
+  </n-form>
+
+  <pre>{{ JSON.stringify(formValue, null, 2) }}
+</pre>
+</template>
+
+<script lang="ts">
+import { defineComponent, ref } from 'vue'
+import { FormInst, useMessage } from 'naive-ui'
+
+export default defineComponent({
+  setup () {
+    const formRef = ref<FormInst | null>(null)
+    const message = useMessage()
+    return {
+      formRef,
+      formValue: ref({
+        user: {
+          name: ''
+        }
+      }),
+      messages: {
+        required: '%s is really really required'
+      },
+      rules: {
+        user: {
+          name: {
+            required: true,
+            trigger: 'blur'
+          }
+        }
+      },
+      handleValidateClick (e: MouseEvent) {
+        e.preventDefault()
+        formRef.value?.validate((errors) => {
+          if (!errors) {
+            message.success('Valid')
+          } else {
+            console.log(errors)
+            message.error('Invalid')
+          }
+        })
+      }
+    }
+  }
+})
+</script>

--- a/src/form/demos/enUS/index.demo-entry.md
+++ b/src/form/demos/enUS/index.demo-entry.md
@@ -17,6 +17,7 @@ async.vue
 disabled.vue
 show-label.vue
 partially-apply-rules.vue
+custom-messages.vue
 ```
 
 ## API
@@ -30,6 +31,7 @@ partially-apply-rules.vue
 | label-width | `number \| string \| 'auto'` | `undefined` | The width of label. Particularly useful when `label-placement` is set to `'left'`,`'auto'` means label width will be auto adjusted. |  |
 | label-align | `'left' \| 'right'` | `-` | Label text alignment. |  |
 | label-placement | `'left' \| 'top'` | `'top'` | Label placement. |  |
+| messages | `FormItemRule` | `undefined` | Validation messages. |  |
 | model | `Object` | `{}` | The object to get/set form item values. |  |
 | rules | `type FormRules = { [itemValidatePath: string]: FormItemRule \| Array<FormItemRule> \| FormRules }` | `{}` | The rules to validate form items. |  |
 | show-feedback | `boolean` | `true` | Whether to show the feedback area. |  |
@@ -51,6 +53,12 @@ partially-apply-rules.vue
 | asyncValidator | `(rule: FormItemRule, value: any, callback: boolean => void) => void` | Asynchronous validation in the form of a callback. |
 | trigger | `string \| Array<string>` | Trigger type. |
 | message | `string` | Text to show when validation fails. |
+
+#### FormMessages Type
+
+<n-alert title="Caveat" type="warning" style="margin-bottom: 16px;">
+  Please see the default messages defined in <n-a href="https://github.com/yiminghe/async-validator/blob/master/src/messages.ts" target="_blank">async-validator</n-a> in order to see which messages you can override.
+</n-alert>
 
 ### FormItem Props
 

--- a/src/form/src/Form.tsx
+++ b/src/form/src/Form.tsx
@@ -20,7 +20,8 @@ import type {
   LabelAlign,
   LabelPlacement,
   FormInst,
-  Size
+  Size,
+  FormMessages
 } from './interface'
 import { ExtractPublicPropTypes, keysOf } from '../../_utils'
 import { formInjectionKey, formItemInstsInjectionKey } from './context'
@@ -57,6 +58,10 @@ const formProps = {
   showLabel: {
     type: Boolean as PropType<boolean | undefined>,
     default: undefined
+  },
+  messages: {
+    type: Object as PropType<Partial<FormMessages>>,
+    default: () => {}
   }
 } as const
 

--- a/src/form/src/FormItem.tsx
+++ b/src/form/src/FormItem.tsx
@@ -297,6 +297,7 @@ export default defineComponent({
       }
       const mergedPath = path ?? '__n_no_path__'
       const validator = new Schema({ [mergedPath]: activeRules as RuleItem[] })
+      validator.messages(NForm?.props.messages)
       return await new Promise((resolve) => {
         void validator.validate(
           { [mergedPath]: value },

--- a/src/form/src/interface.ts
+++ b/src/form/src/interface.ts
@@ -1,5 +1,10 @@
 import { Ref } from 'vue'
-import { ValidateError, RuleItem, ValidateOption } from 'async-validator'
+import {
+  ValidateError,
+  RuleItem,
+  ValidateOption,
+  ValidateMessages
+} from 'async-validator'
 import { FormSetupProps } from './Form'
 
 export interface FormRules {
@@ -90,3 +95,5 @@ export interface FormInst {
 }
 
 export type FormValidationStatus = 'success' | 'error' | 'warning'
+
+export interface FormMessages extends ValidateMessages {}


### PR DESCRIPTION
This PR will add a `messages` prop to `Form` so it's possible to redefine the standard messages from `async-validator` (i.e. https://github.com/yiminghe/async-validator/blob/master/src/messages.ts).