### PR TITLE
feat: add `value` slot to `Badge`

### DIFF
--- a/CHANGELOG.en-US.md
+++ b/CHANGELOG.en-US.md
@@ -15,6 +15,7 @@
 - `useDialog` supports `closeOnEsc` prop.
 - `n-data-table` exports `DataTableFilterState` type.
 - `n-data-table` exports `DataTableSortState` type.
+- `n-badge` adds `value` slot.
 
 ## 2.26.3
 

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -15,6 +15,7 @@
 - `useDialog` 支持 `closeOnEsc` 属性
 - `n-data-table` 导出 `DataTableFilterState` 类型
 - `n-data-table` 导出 `DataTableSortState` 类型
+- `n-badge` adds `value` slot.
 
 ## 2.26.3
 

--- a/src/badge/demos/enUS/custom-content.demo.vue
+++ b/src/badge/demos/enUS/custom-content.demo.vue
@@ -12,5 +12,26 @@ Insert some custom content in it.
     <n-badge value="hot">
       <n-avatar />
     </n-badge>
+    <n-badge processing>
+      <n-avatar />
+
+      <template #value>
+        <n-icon><md-lock /></n-icon>
+      </template>
+    </n-badge>
   </n-space>
 </template>
+
+<script lang="ts">
+import { defineComponent } from 'vue'
+import { MdLock } from '@vicons/ionicons4'
+
+export default defineComponent({
+  components: {
+    MdLock
+  },
+  setup () {
+    return {}
+  }
+})
+</script>

--- a/src/badge/src/Badge.tsx
+++ b/src/badge/src/Badge.tsx
@@ -11,7 +11,13 @@ import {
 import { useConfig, useTheme, useThemeClass } from '../../_mixins'
 import type { ThemeProps } from '../../_mixins'
 import { NBaseSlotMachine, NBaseWave } from '../../_internal'
-import { color2Class, createKey, getTitleAttribute } from '../../_utils'
+import {
+  color2Class,
+  createKey,
+  getTitleAttribute,
+  isSlotEmpty,
+  resolveSlot
+} from '../../_utils'
 import type { ExtractPublicPropTypes } from '../../_utils'
 import { badgeLight } from '../styles'
 import type { BadgeTheme } from '../styles'
@@ -43,7 +49,7 @@ export type BadgeProps = ExtractPublicPropTypes<typeof badgeProps>
 export default defineComponent({
   name: 'Badge',
   props: badgeProps,
-  setup (props) {
+  setup (props, { slots }) {
     const { mergedClsPrefixRef, inlineThemeDisabled, mergedRtlRef } =
       useConfig(props)
     const themeRef = useTheme(
@@ -65,7 +71,9 @@ export default defineComponent({
       return (
         props.show &&
         (props.dot ||
-          (props.value !== undefined && !(!props.showZero && props.value <= 0)))
+          (props.value !== undefined &&
+            !(!props.showZero && props.value <= 0)) ||
+          !isSlotEmpty(slots.value))
       )
     })
     onMounted(() => {
@@ -150,14 +158,16 @@ export default defineComponent({
                   class={`${mergedClsPrefix}-badge-sup`}
                   title={getTitleAttribute(this.value)}
                 >
-                  {!this.dot ? (
-                    <NBaseSlotMachine
-                      clsPrefix={mergedClsPrefix}
-                      appeared={this.appeared}
-                      max={this.max}
-                      value={this.value}
-                    />
-                  ) : null}
+                  {resolveSlot($slots.value, () => [
+                    !this.dot ? (
+                      <NBaseSlotMachine
+                        clsPrefix={mergedClsPrefix}
+                        appeared={this.appeared}
+                        max={this.max}
+                        value={this.value}
+                      />
+                    ) : null
+                  ])}
                   {this.processing ? (
                     <NBaseWave clsPrefix={mergedClsPrefix} />
                   ) : null}


### PR DESCRIPTION
This PR adds a `value` slot to `Badge` so you can even use icons as a badge.