### PR TITLE
feat: add status class to `NStep`

### DIFF
--- a/CHANGELOG.en-US.md
+++ b/CHANGELOG.en-US.md
@@ -15,6 +15,7 @@
 - `n-badge` adds `value` slot.
 - `n-form` adds `messages` prop.
 - `n-data-table`'s column supports `cellProps` prop, closes [#2625](https://github.com/TuSimple/naive-ui/issues/2625).
+- `n-step` adds class to distinguish status.
 
 ## 2.26.4
 

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -15,6 +15,7 @@
 - `n-badge` 新增 `value` slot
 - `n-form` 新增 `messages` 属性
 - `n-data-table` 的 column 支持 `cellProps` 属性，关闭 [#2625](https://github.com/TuSimple/naive-ui/issues/2625)
+- `n-step` adds class to distinguish status.
 
 ## 2.26.4
 

--- a/src/steps/src/Step.tsx
+++ b/src/steps/src/Step.tsx
@@ -150,7 +150,8 @@ export default defineComponent({
         class={[
           `${mergedClsPrefix}-step`,
           this.themeClass,
-          descriptionNode && `${mergedClsPrefix}-step--show-description`
+          descriptionNode && `${mergedClsPrefix}-step--show-description`,
+          `${mergedClsPrefix}-step--${this.mergedStatus}-status`
         ]}
         style={this.cssVars as CSSProperties}
       >


### PR DESCRIPTION
This PR will add a status dependent class to the rendered output of `NStep` so it's possible to differentiate the steps' status'.