### PR TITLE
Document's table meta row sets wrong number of columns

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
     "codesandbox": "^2.2.3",
     "cross-env": "^7.0.3",
     "cssnano": "^5.0.5",
-    "esbuild": "0.14.27",
+    "esbuild": "0.14.28",
     "eslint": "^8.6.0",
     "eslint-config-prettier": "^8.3.0",
     "eslint-config-standard": "^16.0.2",

--- a/src/carousel/tests/Carousel.spec.tsx
+++ b/src/carousel/tests/Carousel.spec.tsx
@@ -379,4 +379,32 @@ describe('n-carousel', () => {
     )
     wrapper.unmount()
   })
+
+  it('should work with `show-dots` prop', async () => {
+    const wrapper = mount(NCarousel, {
+      slots: {
+        default: () => {
+          return [
+            h('img', {
+              style: 'width: 100%; height: 240px; object-fit: cover;',
+              src: 'https://naive-ui.oss-cn-beijing.aliyuncs.com/carousel-img/carousel3.jpeg'
+            }),
+            h('img', {
+              style: 'width: 100%; height: 240px; object-fit: cover;',
+              src: 'https://naive-ui.oss-cn-beijing.aliyuncs.com/carousel-img/carousel4.jpeg'
+            })
+          ]
+        }
+      }
+    })
+    await sleep(100)
+    expect(wrapper.find('.n-carousel__dots').exists()).toBe(true)
+
+    await wrapper.setProps({
+      showDots: false
+    })
+    await sleep(100)
+    expect(wrapper.find('.n-carousel__dots').exists()).not.toBe(true)
+    wrapper.unmount()
+  })
 })

--- a/src/dialog/demos/enUS/index.demo-entry.md
+++ b/src/dialog/demos/enUS/index.demo-entry.md
@@ -58,7 +58,7 @@ action.vue
 ### DialogOptions Properties
 
 | Name | Type | Default | Description | Version |
-| --- | --- | --- | --- | --- | --- |
+| --- | --- | --- | --- | --- | 
 | action | `() => VNodeChild` | `undefined` | Content of the operation area, must be a `render` function. |  |
 | bordered | `boolean` | `false` | Whether to show `border`. |  |
 | closable | `boolean` | `true` | Whether to show `close` icon. |  |


### PR DESCRIPTION
The content of the table has only 5 columns but the meta row (the row right below the header. It includes such as "| -- |") had 6 columns.