### PR TITLE
Document's table meta row sets wrong number of columns (Re - #2691)

### DIFF
--- a/src/dialog/demos/enUS/index.demo-entry.md
+++ b/src/dialog/demos/enUS/index.demo-entry.md
@@ -58,7 +58,7 @@ action.vue
 ### DialogOptions Properties
 
 | Name | Type | Default | Description | Version |
-| --- | --- | --- | --- | --- | --- |
+| --- | --- | --- | --- | --- |
 | action | `() => VNodeChild` | `undefined` | Content of the operation area, must be a `render` function. |  |
 | bordered | `boolean` | `false` | Whether to show `border`. |  |
 | closable | `boolean` | `true` | Whether to show `close` icon. |  |

--- a/src/tabs/demos/enUS/basic.demo.vue
+++ b/src/tabs/demos/enUS/basic.demo.vue
@@ -17,7 +17,14 @@
     </n-tabs>
   </n-card>
   <n-card>
-    <n-tabs default-value="signin" size="large" animated>
+    <n-tabs
+      class="card-tabs"
+      default-value="signin"
+      size="large"
+      animated
+      style="margin: 0 -4px"
+      pane-style="padding-left: 4px; padding-right: 4px; box-sizing: border-box;"
+    >
       <n-tab-pane name="signin" tab="Sign in">
         <n-form>
           <n-form-item-row label="Username">
@@ -50,3 +57,9 @@
     </n-tabs>
   </n-card>
 </template>
+
+<style>
+.card-tabs .n-tabs-nav--bar-type {
+  padding-left: 4px;
+}
+</style>

--- a/src/tabs/demos/zhCN/basic.demo.vue
+++ b/src/tabs/demos/zhCN/basic.demo.vue
@@ -17,7 +17,14 @@
     </n-tabs>
   </n-card>
   <n-card>
-    <n-tabs default-value="signin" size="large" animated>
+    <n-tabs
+      class="card-tabs"
+      default-value="signin"
+      size="large"
+      animated
+      style="margin: 0 -4px"
+      pane-style="padding-left: 4px; padding-right: 4px; box-sizing: border-box;"
+    >
       <n-tab-pane name="signin" tab="登录">
         <n-form>
           <n-form-item-row label="用户名">
@@ -50,3 +57,9 @@
     </n-tabs>
   </n-card>
 </template>
+
+<style>
+.card-tabs .n-tabs-nav--bar-type {
+  padding-left: 4px;
+}
+</style>


### PR DESCRIPTION
The content of the table has only 5 columns but the meta row (the row right below the header. It includes such as "| -- |") had 6 columns.

(This PR has been now properly checkouted from branch `doc`)