### PR TITLE
Document's table meta row sets wrong number of columns (Re - #2691) 

### DIFF
--- a/src/dialog/demos/enUS/index.demo-entry.md
+++ b/src/dialog/demos/enUS/index.demo-entry.md
@@ -58,7 +58,7 @@ action.vue
 ### DialogOptions Properties
 
 | Name | Type | Default | Description | Version |
-| --- | --- | --- | --- | --- | --- |
+| --- | --- | --- | --- | --- |
 | action | `() => VNodeChild` | `undefined` | Content of the operation area, must be a `render` function. |  |
 | bordered | `boolean` | `false` | Whether to show `border`. |  |
 | closable | `boolean` | `true` | Whether to show `close` icon. |  |


### PR DESCRIPTION
The content of the table has only 5 columns but the meta row (the row right below the header. It includes such as "| -- |") had 6 columns.

(This PR has been now properly checkouted from branch `docs` and requesting merge to `docs`)