### PR TITLE
fix(message): messageReactive.destroy() shouldn't throw when messageReactiveInstance has already been hidden

### DIFF
--- a/src/message/src/MessageProvider.tsx
+++ b/src/message/src/MessageProvider.tsx
@@ -131,7 +131,7 @@ export default defineComponent({
         content,
         key,
         destroy: () => {
-          messageRefs.value[key].hide()
+          messageRefs.value[key]?.hide()
         }
       })
       const { max } = props


### PR DESCRIPTION
有时用户会获得 MessageReactive 的实例，希望后续有机会主动销毁此 message。
但是调用 message.destroy 时，可能因为此消息的 duration 时间已经过去了，这时 message.destroy() 会报错。
此时不报错似乎更加符合需求。

User may need MessageReactive instance for closing the message directly.
But when calling message.destroy(), the message might already been hidden because the duration setting.
It seems that calling message.destroy on an hidden message shouldn't throw exception.

```
 messageReactive = message.info("3 * 3 * 4 * 4 * ?", {
            duration: 3000,
          });
// after 3000ms
messageReactive.destroy();  // current behavior: throw exception. expected behavior: fail silently
```

Alternative approach:
1. reveal the show/hide status of the message
2. destroy/hide message also set the messageReactiveInstance's value to null