### PR TITLE
Fix/keyboard events

### DIFF
--- a/CHANGELOG.en-US.md
+++ b/CHANGELOG.en-US.md
@@ -5,6 +5,7 @@
 - Fix `n-tree` throw error when use `pattern` prop filter the tree node, closes [#2960].
 - Fix `n-watermark` not working when provided `cls-prefix`
 - Fix `n-dropdown`'s incorrect render arrow when props `show-arrow: true` [#2977](https://github.com/TuSimple/naive-ui/issues/2977)
+- Fix `e.code` in keyboard events, now using `e.key` for better compatibility.
 
 ### Feats
 

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -5,6 +5,7 @@
 - 修复 `n-tree` 使用 `pattern` 属性过滤树节点时报错, 关闭 [#2960].
 - 修复 `n-watermark` 在全局配置了 `cls-prefix` 时失效
 - 修复 `n-dropdown` 在 `show-arrow: true` 情况下不显示箭头的问题，关闭[#2977](https://github.com/TuSimple/naive-ui/issues/2977)
+- Fix `e.code` in keyboard events, now using `e.key` for better compatibility
 
 ### Feats
 

--- a/src/_internal/selection/src/Selection.tsx
+++ b/src/_internal/selection/src/Selection.tsx
@@ -237,7 +237,7 @@ export default defineComponent({
       doDeleteOption(option)
     }
     function handlePatternKeyDown (e: KeyboardEvent): void {
-      if (e.code === 'Backspace' && !isCompositingRef.value) {
+      if (e.key === 'Backspace' && !isCompositingRef.value) {
         if (!props.pattern.length) {
           const { selectedOptions } = props
           if (selectedOptions?.length) {

--- a/src/auto-complete/src/AutoComplete.tsx
+++ b/src/auto-complete/src/AutoComplete.tsx
@@ -208,9 +208,8 @@ export default defineComponent({
       }, 0)
     }
     function handleKeyDown (e: KeyboardEvent): void {
-      switch (e.code) {
+      switch (e.key) {
         case 'Enter':
-        case 'NumpadEnter':
           if (!isComposingRef.value) {
             const pendingOptionTmNode = menuInstRef.value?.getPendingTmNode()
             if (pendingOptionTmNode) {

--- a/src/button/src/Button.tsx
+++ b/src/button/src/Button.tsx
@@ -160,9 +160,8 @@ const Button = defineComponent({
       }
     }
     const handleKeyup = (e: KeyboardEvent): void => {
-      switch (e.code) {
+      switch (e.key) {
         case 'Enter':
-        case 'NumpadEnter':
           if (!props.keyboard) {
             return
           }
@@ -170,9 +169,8 @@ const Button = defineComponent({
       }
     }
     const handleKeydown = (e: KeyboardEvent): void => {
-      switch (e.code) {
+      switch (e.key) {
         case 'Enter':
-        case 'NumpadEnter':
           if (!props.keyboard || props.loading) {
             e.preventDefault()
             return

--- a/src/carousel/src/CarouselDots.tsx
+++ b/src/carousel/src/CarouselDots.tsx
@@ -36,10 +36,9 @@ export default defineComponent({
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     const NCarousel = inject(carouselMethodsInjectionKey, null)!
     function handleKeydown (e: KeyboardEvent, current: number): void {
-      switch (e.code) {
+      switch (e.key) {
         case 'Enter':
-        case 'NumpadEnter':
-        case 'Space':
+        case ' ':
           NCarousel.to(current)
           return
       }

--- a/src/cascader/src/Cascader.tsx
+++ b/src/cascader/src/Cascader.tsx
@@ -606,12 +606,11 @@ export default defineComponent({
     }
     function handleKeyUp (e: KeyboardEvent): void {
       if (happensIn(e, 'action')) return
-      switch (e.code) {
-        case 'Space':
+      switch (e.key) {
+        case ' ':
           if (props.filterable) return
         // eslint-disable-next-line no-fallthrough
         case 'Enter':
-        case 'NumpadEnter':
           if (!mergedShowRef.value) {
             openMenu()
           } else {
@@ -749,8 +748,8 @@ export default defineComponent({
       }
     }
     function handleKeyDown (e: KeyboardEvent): void {
-      switch (e.code) {
-        case 'Space':
+      switch (e.key) {
+        case ' ':
         case 'ArrowDown':
         case 'ArrowUp':
           if (props.filterable && mergedShowRef.value) {

--- a/src/checkbox/src/Checkbox.tsx
+++ b/src/checkbox/src/Checkbox.tsx
@@ -204,16 +204,15 @@ export default defineComponent({
     }
     function handleKeyUp (e: KeyboardEvent): void {
       if (mergedDisabledRef.value) return
-      switch (e.code) {
-        case 'Space':
+      switch (e.key) {
+        case ' ':
         case 'Enter':
-        case 'NumpadEnter':
           toggle(e)
       }
     }
     function handleKeyDown (e: KeyboardEvent): void {
-      switch (e.code) {
-        case 'Space':
+      switch (e.key) {
+        case ' ':
           e.preventDefault()
       }
     }

--- a/src/date-picker/src/DatePicker.tsx
+++ b/src/date-picker/src/DatePicker.tsx
@@ -477,7 +477,7 @@ export default defineComponent({
       uncontrolledShowRef.value = show
     }
     function handleKeyDown (e: KeyboardEvent): void {
-      if (e.code === 'Escape') {
+      if (e.key === 'Escape') {
         closeCalendar({
           returnFocus: true
         })

--- a/src/date-picker/src/panel/use-panel-common.ts
+++ b/src/date-picker/src/panel/use-panel-common.ts
@@ -109,7 +109,7 @@ function usePanelCommon (props: UsePanelCommonProps) {
     }
   }
   function handlePanelKeyDown (e: KeyboardEvent): void {
-    if (e.code === 'Tab' && e.target === selfRef.value && keyboardState.shift) {
+    if (e.key === 'Tab' && e.target === selfRef.value && keyboardState.shift) {
       e.preventDefault()
       doTabOut()
     }

--- a/src/date-picker/src/utils.ts
+++ b/src/date-picker/src/utils.ts
@@ -29,7 +29,7 @@ function getDerivedTimeFromKeyboardEvent (
 ): number {
   const now = getTime(Date.now())
   if (typeof prevValue !== 'number') return now
-  switch (event.code) {
+  switch (event.key) {
     case 'ArrowUp':
       return getTime(addDays(prevValue, -7))
     case 'ArrowDown':

--- a/src/dynamic-tags/src/DynamicTags.tsx
+++ b/src/dynamic-tags/src/DynamicTags.tsx
@@ -143,9 +143,8 @@ export default defineComponent({
       doChange(tags)
     }
     function handleInputKeyUp (e: KeyboardEvent): void {
-      switch (e.code) {
+      switch (e.key) {
         case 'Enter':
-        case 'NumpadEnter':
           handleInputConfirm()
       }
     }

--- a/src/image/src/ImagePreview.tsx
+++ b/src/image/src/ImagePreview.tsx
@@ -79,7 +79,7 @@ export default defineComponent({
     }
 
     function handleKeydown (e: KeyboardEvent): void {
-      switch (e.code) {
+      switch (e.key) {
         case 'ArrowLeft':
           props.onPrev?.()
           break

--- a/src/input-number/src/InputNumber.tsx
+++ b/src/input-number/src/InputNumber.tsx
@@ -411,7 +411,7 @@ export default defineComponent({
       doMinus()
     }
     function handleKeyDown (e: KeyboardEvent): void {
-      if (e.code === 'Enter' || e.code === 'NumpadEnter') {
+      if (e.key === 'Enter') {
         if (e.target === inputInstRef.value?.wrapperElRef) {
           // hit input wrapper
           // which means not activated
@@ -421,14 +421,14 @@ export default defineComponent({
         if (value !== false) {
           inputInstRef.value?.deactivate()
         }
-      } else if (e.code === 'ArrowUp') {
+      } else if (e.key === 'ArrowUp') {
         if (props.keyboard.ArrowUp === false) return
         e.preventDefault()
         const value = deriveValueFromDisplayedValue()
         if (value !== false) {
           doAdd()
         }
-      } else if (e.code === 'ArrowDown') {
+      } else if (e.key === 'ArrowDown') {
         if (props.keyboard.ArrowDown === false) return
         e.preventDefault()
         const value = deriveValueFromDisplayedValue()

--- a/src/input/src/Input.tsx
+++ b/src/input/src/Input.tsx
@@ -604,12 +604,11 @@ export default defineComponent({
     }
     function handleWrapperKeyDown (e: KeyboardEvent): void {
       props.onKeydown?.(e)
-      switch (e.code) {
+      switch (e.key) {
         case 'Escape':
           handleWrapperKeyDownEsc()
           break
         case 'Enter':
-        case 'NumpadEnter':
           handleWrapperKeyDownEnter(e)
           break
       }

--- a/src/mention/src/Mention.tsx
+++ b/src/mention/src/Mention.tsx
@@ -280,23 +280,22 @@ export default defineComponent({
       }, 0)
     }
     function handleInputKeyDown (e: KeyboardEvent): void {
-      if (e.code === 'ArrowLeft' || e.code === 'ArrowRight') {
+      if (e.key === 'ArrowLeft' || e.key === 'ArrowRight') {
         if (inputInstRef.value?.isCompositing) return
         syncAfterCursorMove()
       } else if (
-        e.code === 'ArrowUp' ||
-        e.code === 'ArrowDown' ||
-        e.code === 'Enter' ||
-        e.code === 'NumpadEnter'
+        e.key === 'ArrowUp' ||
+        e.key === 'ArrowDown' ||
+        e.key === 'Enter'
       ) {
         if (inputInstRef.value?.isCompositing) return
         const { value: selectMenuInst } = selectMenuInstRef
         if (showMenuRef.value) {
           if (selectMenuInst) {
             e.preventDefault()
-            if (e.code === 'ArrowUp') {
+            if (e.key === 'ArrowUp') {
               selectMenuInst.prev()
-            } else if (e.code === 'ArrowDown') {
+            } else if (e.key === 'ArrowDown') {
               selectMenuInst.next()
             } else {
               // Enter

--- a/src/pagination/src/Pagination.tsx
+++ b/src/pagination/src/Pagination.tsx
@@ -286,7 +286,7 @@ export default defineComponent({
       doUpdatePageSize(value)
     }
     function handleQuickJumperKeyUp (e: KeyboardEvent): void {
-      if (e.code === 'Enter' || e.code === 'NumpadEnter') {
+      if (e.key === 'Enter') {
         const page = parseInt(jumperValueRef.value)
         if (!Number.isNaN(page)) {
           doUpdatePage(Math.max(1, Math.min(page, mergedPageCountRef.value)))

--- a/src/popover/src/Popover.tsx
+++ b/src/popover/src/Popover.tsx
@@ -394,7 +394,7 @@ export default defineComponent({
     }
     function handleKeydown (e: KeyboardEvent): void {
       if (!props.internalTrapFocus) return
-      if (e.code === 'Escape') {
+      if (e.key === 'Escape') {
         clearShowTimer()
         clearHideTimer()
         doUpdateShow(false)

--- a/src/select/src/Select.tsx
+++ b/src/select/src/Select.tsx
@@ -606,15 +606,14 @@ export default defineComponent({
     // keyboard events
     // also for menu keydown
     function handleKeydown (e: KeyboardEvent): void {
-      switch (e.code) {
-        case 'Space':
+      switch (e.key) {
+        case ' ':
           if (props.filterable) break
           else {
             e.preventDefault()
           }
         // eslint-disable-next-line no-fallthrough
         case 'Enter':
-        case 'NumpadEnter':
           if (!triggerRef.value?.isCompositing) {
             if (mergedShowRef.value) {
               const pendingTmNode = menuRef.value?.getPendingTmNode()

--- a/src/slider/src/Slider.tsx
+++ b/src/slider/src/Slider.tsx
@@ -400,7 +400,7 @@ export default defineComponent({
     function handleRailKeyDown (e: KeyboardEvent): void {
       if (mergedDisabledRef.value) return
       const { vertical, reverse } = props
-      switch (e.code) {
+      switch (e.key) {
         case 'ArrowUp':
           e.preventDefault()
           handleStepValue(vertical && reverse ? -1 : 1)

--- a/src/switch/src/Switch.tsx
+++ b/src/switch/src/Switch.tsx
@@ -156,7 +156,7 @@ export default defineComponent({
     }
     function handleKeyup (e: KeyboardEvent): void {
       if (props.loading || mergedDisabledRef.value) return
-      if (e.code === 'Space') {
+      if (e.key === ' ') {
         if (mergedValueRef.value !== props.checkedValue) {
           doUpdateValue(props.checkedValue)
         } else {
@@ -167,7 +167,7 @@ export default defineComponent({
     }
     function handleKeydown (e: KeyboardEvent): void {
       if (props.loading || mergedDisabledRef.value) return
-      if (e.code === 'Space') {
+      if (e.key === ' ') {
         e.preventDefault()
         pressedRef.value = true
       }

--- a/src/time-picker/src/TimePicker.tsx
+++ b/src/time-picker/src/TimePicker.tsx
@@ -416,7 +416,7 @@ export default defineComponent({
       })
     }
     function handleMenuKeyDown (e: KeyboardEvent): void {
-      switch (e.code) {
+      switch (e.key) {
         case 'Escape':
           closePanel({
             returnFocus: true

--- a/src/tree-select/src/TreeSelect.tsx
+++ b/src/tree-select/src/TreeSelect.tsx
@@ -532,7 +532,7 @@ export default defineComponent({
       }
     }
     function handleKeyup (e: KeyboardEvent): void {
-      if (e.code === 'Enter' || e.code === 'NumpadEnter') {
+      if (e.key === 'Enter') {
         if (mergedShowRef.value) {
           treeHandleKeyup(e)
           if (!props.multiple) {
@@ -543,13 +543,13 @@ export default defineComponent({
           openMenu()
         }
         e.preventDefault()
-      } else if (e.code === 'Escape') {
+      } else if (e.key === 'Escape') {
         closeMenu()
         focusSelection()
       } else {
         if (mergedShowRef.value) {
           treeHandleKeyup(e)
-        } else if (e.code === 'ArrowDown') {
+        } else if (e.key === 'ArrowDown') {
           openMenu()
         }
       }

--- a/src/tree/src/keyboard.tsx
+++ b/src/tree/src/keyboard.tsx
@@ -34,9 +34,7 @@ export function useKeyboard ({
   function handleKeyup (e: KeyboardEvent): void {
     const { value: pendingNodeKey } = pendingNodeKeyRef
     if (pendingNodeKey === null) {
-      if (
-        ['ArrowDown', 'ArrowUp', 'ArrowLeft', 'ArrowRight'].includes(e.code)
-      ) {
+      if (['ArrowDown', 'ArrowUp', 'ArrowLeft', 'ArrowRight'].includes(e.key)) {
         if (pendingNodeKey === null) {
           const { value: fNodes } = fNodesRef
           let fIndex = 0
@@ -53,9 +51,9 @@ export function useKeyboard ({
       const { value: fNodes } = fNodesRef
       let fIndex = fNodes.findIndex((tmNode) => tmNode.key === pendingNodeKey)
       if (!~fIndex) return
-      if (e.code === 'Enter' || e.code === 'NumpadEnter') {
+      if (e.key === 'Enter') {
         handleSelect(fNodes[fIndex])
-      } else if (e.code === 'ArrowDown') {
+      } else if (e.key === 'ArrowDown') {
         fIndex += 1
         while (fIndex < fNodes.length) {
           if (!fNodes[fIndex].disabled) {
@@ -64,7 +62,7 @@ export function useKeyboard ({
           }
           fIndex += 1
         }
-      } else if (e.code === 'ArrowUp') {
+      } else if (e.key === 'ArrowUp') {
         fIndex -= 1
         while (fIndex >= 0) {
           if (!fNodes[fIndex].disabled) {
@@ -73,7 +71,7 @@ export function useKeyboard ({
           }
           fIndex -= 1
         }
-      } else if (e.code === 'ArrowLeft') {
+      } else if (e.key === 'ArrowLeft') {
         const pendingNode = fNodes[fIndex]
         if (
           pendingNode.isLeaf ||
@@ -86,7 +84,7 @@ export function useKeyboard ({
         } else {
           handleSwitcherClick(pendingNode)
         }
-      } else if (e.code === 'ArrowRight') {
+      } else if (e.key === 'ArrowRight') {
         const pendingNode = fNodes[fIndex]
         if (pendingNode.isLeaf) return
         if (!mergedExpandedKeysRef.value.includes(pendingNodeKey)) {
@@ -106,7 +104,7 @@ export function useKeyboard ({
     }
   }
   function handleKeydown (e: KeyboardEvent): void {
-    switch (e.code) {
+    switch (e.key) {
       case 'ArrowUp':
       case 'ArrowDown':
         e.preventDefault()


### PR DESCRIPTION
**Description**

The use of the `e.code` property can cause problems with some keyboard layouts, for example the AZERTY layout.
Using `e.key` will improve compatibility.

**Related**

- [An interesting article on the subject](https://developer.chrome.com/blog/keyboardevent-keys-codes/#:~:text=%23%20The%20key%20attribute&text=It%27s%20also%20set%20to%20a,layout%2C%20locale%20and%20modifier%20keys)
- [Demo](https://w3c.github.io/uievents/tools/key-event-viewer.html) for visualizing all the attributes associated with KeyboardEvent