### PR TITLE
feat(tree):  click the content to select it

### DIFF
--- a/CHANGELOG.en-US.md
+++ b/CHANGELOG.en-US.md
@@ -36,6 +36,7 @@
 - `n-popselect` adds `virtual-scroll` prop.
 - `n-data-table` adds `scrollTo` method, closes [#2570](https://github.com/TuSimple/naive-ui/issues/2570).
 - `n-slider` adds `thumb` slot.
+- `n-tree` under `checkable = true`, click the content to select it
 
 ## 2.30.3
 

--- a/CHANGELOG.en-US.md
+++ b/CHANGELOG.en-US.md
@@ -1,5 +1,13 @@
 # CHANGELOG
 
+## 2.30.5
+
+### Fixes
+
+### Feats
+
+- `n-tree` under `checkable = true`, click the content to select it.
+
 ## 2.30.4
 
 ### Fixes
@@ -36,7 +44,6 @@
 - `n-popselect` adds `virtual-scroll` prop.
 - `n-data-table` adds `scrollTo` method, closes [#2570](https://github.com/TuSimple/naive-ui/issues/2570).
 - `n-slider` adds `thumb` slot.
-- `n-tree` under `checkable = true`, click the content to select it
 
 ## 2.30.3
 

--- a/CHANGELOG.en-US.md
+++ b/CHANGELOG.en-US.md
@@ -8,7 +8,7 @@
 
 ### Feats
 
-- `n-tree` under `checkable = true`, click the content to select it.
+- `n-tree` adds `check-on-click` prop to control `checked` status
 
 ## 2.30.4
 

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -36,6 +36,7 @@
 - `n-popselect` 新增 `virtual-scroll` 属性
 - `n-data-table` 新增 `scrollTo` 方法，关闭 [#2570](https://github.com/TuSimple/naive-ui/issues/2570)
 - `n-slider` 新增 `thumb` 插槽
+- `n-tree` 在 `checkable = true ` 下，点击文字即可进行选中
 
 ## 2.30.3
 

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -1,5 +1,13 @@
 # CHANGELOG
 
+## 2.30.5
+
+### Fixes
+
+### Feats
+
+- `n-tree` 在 `checkable = true ` 下，点击文字即可进行选中
+
 ## 2.30.4
 
 ### Fixes
@@ -36,7 +44,6 @@
 - `n-popselect` 新增 `virtual-scroll` 属性
 - `n-data-table` 新增 `scrollTo` 方法，关闭 [#2570](https://github.com/TuSimple/naive-ui/issues/2570)
 - `n-slider` 新增 `thumb` 插槽
-- `n-tree` 在 `checkable = true ` 下，点击文字即可进行选中
 
 ## 2.30.3
 

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -8,7 +8,7 @@
 
 ### Feats
 
-- `n-tree` 在 `checkable = true ` 下，点击文字即可进行选中
+- `n-tree` 新增属性 `check-on-click` 来控制可选状态下的选中交互方式
 
 ## 2.30.4
 

--- a/src/tree/demos/zhCN/index.demo-entry.md
+++ b/src/tree/demos/zhCN/index.demo-entry.md
@@ -32,7 +32,7 @@ scroll-debug.vue
 ### Tree Props
 
 | 名称 | 类型 | 默认值 | 说明 | 版本 |
-| --- | --- | --- | --- | --- |
+| --- | --- | --- | --- | --- | --- |
 | allow-checking-not-loaded | `boolean` | `false` | 是否允许级联勾选还没有完全加载的节点。如果你要用这个属性，请记住 `checked-keys` 可能是不完整的，并且请注意勾选行为和后端计算逻辑的一致性，尤其是有禁用节点的情况下 | 2.28.1 |
 | allow-drop | `(info: { dropPosition: DropPosition, node: TreeOption, phase: 'drag' \| 'drop' }) => boolean` | 一个不允许 drop 在叶节点内部的函数 | 是否允许 drop |  |
 | block-line | `boolean` | `false` | 节点整行撑开 |  |
@@ -52,6 +52,7 @@ scroll-debug.vue
 | draggable | `boolean` | `false` | 是否可拖拽 |  |
 | expand-on-dragenter | `boolean` | `true` | 是否在拖入后展开节点 |  |
 | expand-on-click | `boolean` | `false` | 是否在点击节点后展开或收缩节点 | 2.29.1 |
+| check-on-click | `boolean | (node: TreeOption) => boolean` | `true` | 是否允许点击`label`节点进行选中，仅在`checkable = true`下生效 | NEXT_VERSION |
 | expanded-keys | `Array<string \| number>` | `undefined` | 如果设定则展开受控 |  |
 | filter | `(pattern: string, node: TreeOption) => boolean` | 一个简单的字符串过滤算法 | 基于 pattern 指定过滤节点的函数 |  |
 | indeterminate-keys | `Array<string \| number>` | `undefined` | 部分选中选项的 key |  |

--- a/src/tree/src/Tree.tsx
+++ b/src/tree/src/Tree.tsx
@@ -54,7 +54,8 @@ import type {
   RenderPrefix,
   RenderSuffix,
   RenderSwitcherIcon,
-  TreeNodeProps
+  TreeNodeProps,
+  CheckOnClick
 } from './interface'
 import { treeInjectionKey } from './interface'
 import MotionWrapper from './MotionWrapper'
@@ -150,6 +151,10 @@ const treeProps = {
   blockNode: Boolean,
   blockLine: Boolean,
   disabled: Boolean,
+  checkOnClick: {
+    type: [Boolean, Function] as PropType<CheckOnClick>,
+    default: true
+  },
   checkedKeys: Array as PropType<Key[]>,
   defaultCheckedKeys: {
     type: Array as PropType<Key[]>,
@@ -1266,6 +1271,7 @@ export default defineComponent({
       renderSwitcherIconRef: toRef(props, 'renderSwitcherIcon'),
       labelFieldRef: toRef(props, 'labelField'),
       multipleRef: toRef(props, 'multiple'),
+      checkOnClickRef: toRef(props, 'checkOnClick'),
       handleSwitcherClick,
       handleDragEnd,
       handleDragEnter,

--- a/src/tree/src/TreeNode.tsx
+++ b/src/tree/src/TreeNode.tsx
@@ -100,9 +100,26 @@ const TreeNode = defineComponent({
           : true)
     )
 
+    const checkableRef = computed(
+      () =>
+        NTree.checkableRef.value &&
+        (NTree.cascadeRef.value ||
+          NTree.mergedCheckStrategyRef.value !== 'child' ||
+          props.tmNode.isLeaf)
+    )
+
+    const checkedRef = useMemo(() =>
+      NTree.displayedCheckedKeysRef.value.includes(props.tmNode.key)
+    )
+
+    const indeterminateRef = useMemo(() =>
+      NTree.displayedIndeterminateKeysRef.value.includes(props.tmNode.key)
+    )
+
     function _handleClick (e: MouseEvent): void {
       const { value: expandOnClick } = NTree.expandOnClickRef
       const { value: selectable } = selectableRef
+      const { value: checkable } = checkableRef
       if (!selectable && !expandOnClick) return
       if (happensIn(e, 'checkbox') || happensIn(e, 'switcher')) return
       const { tmNode } = props
@@ -111,6 +128,9 @@ const TreeNode = defineComponent({
       }
       if (expandOnClick && !tmNode.isLeaf) {
         handleSwitcherClick()
+      }
+      if (checkable && !tmNode.children) {
+        handleCheck(!checkedRef.value)
       }
     }
 
@@ -210,12 +230,8 @@ const TreeNode = defineComponent({
       highlight: useMemo(() => {
         return NTree.highlightKeySetRef.value?.has(props.tmNode.key)
       }),
-      checked: useMemo(() =>
-        NTree.displayedCheckedKeysRef.value.includes(props.tmNode.key)
-      ),
-      indeterminate: useMemo(() =>
-        NTree.displayedIndeterminateKeysRef.value.includes(props.tmNode.key)
-      ),
+      checked: checkedRef,
+      indeterminate: indeterminateRef,
       selected: useMemo(() =>
         NTree.mergedSelectedKeysRef.value.includes(props.tmNode.key)
       ),
@@ -223,13 +239,7 @@ const TreeNode = defineComponent({
         NTree.mergedExpandedKeysRef.value.includes(props.tmNode.key)
       ),
       disabled: disabledRef,
-      checkable: computed(
-        () =>
-          NTree.checkableRef.value &&
-          (NTree.cascadeRef.value ||
-            NTree.mergedCheckStrategyRef.value !== 'child' ||
-            props.tmNode.isLeaf)
-      ),
+      checkable: checkableRef,
       checkboxDisabled: computed(() => !!props.tmNode.rawNode.checkboxDisabled),
       selectable: selectableRef,
       expandOnClick: NTree.expandOnClickRef,

--- a/src/tree/src/TreeNode.tsx
+++ b/src/tree/src/TreeNode.tsx
@@ -41,7 +41,8 @@ const TreeNode = defineComponent({
       nodePropsRef,
       indentRef,
       blockLineRef,
-      checkboxPlacementRef
+      checkboxPlacementRef,
+      checkOnClickRef
     } = NTree
 
     const disabledRef = computed(
@@ -116,6 +117,13 @@ const TreeNode = defineComponent({
       NTree.displayedIndeterminateKeysRef.value.includes(props.tmNode.key)
     )
 
+    const checkOnClick = useMemo(() => {
+      if (typeof checkOnClickRef.value === 'boolean') {
+        return checkOnClickRef.value
+      }
+      return checkOnClickRef.value(props.tmNode.rawNode)
+    })
+
     function _handleClick (e: MouseEvent): void {
       const { value: expandOnClick } = NTree.expandOnClickRef
       const { value: selectable } = selectableRef
@@ -129,7 +137,7 @@ const TreeNode = defineComponent({
       if (expandOnClick && !tmNode.isLeaf) {
         handleSwitcherClick()
       }
-      if (checkable && !tmNode.children) {
+      if (checkable && checkOnClick.value && !tmNode.children) {
         handleCheck(!checkedRef.value)
       }
     }

--- a/src/tree/src/interface.ts
+++ b/src/tree/src/interface.ts
@@ -39,6 +39,8 @@ export type RenderPrefix = RenderTreePart
 
 export type RenderSuffix = RenderTreePart
 
+export type CheckOnClick = (option: TreeOption) => void
+
 export type TreeNodeProps = (info: { option: TreeOption }) => HTMLAttributes
 
 export interface TreeDragInfo {
@@ -108,6 +110,7 @@ export interface TreeInjection {
   labelFieldRef: Ref<string>
   nodePropsRef: Ref<TreeNodeProps | undefined>
   multipleRef: Ref<boolean>
+  checkOnClickRef: Ref<boolean | CheckOnClick>
   checkboxPlacementRef: 'left' | 'right'
   internalTreeSelect: boolean
   handleSwitcherClick: (node: TreeNode<TreeOption>) => void

--- a/src/tree/tests/Tree.spec.ts
+++ b/src/tree/tests/Tree.spec.ts
@@ -1,6 +1,6 @@
 import { mount } from '@vue/test-utils'
 import { nextTick } from 'vue'
-import { NTree } from '../index'
+import { NTree, TreeOption } from '../index'
 
 describe('n-tree', () => {
   it('should work with import on demand', () => {
@@ -480,12 +480,22 @@ describe('n-tree', () => {
     await node[0].trigger('click')
     await node[1].trigger('click')
     expect(wrapper.findAll('.n-checkbox--checked').length).toBe(2)
+    await wrapper.setProps({ checkOnClick: false })
+    await node[0].trigger('click')
+    expect(wrapper.findAll('.n-checkbox--checked').length).toBe(2)
+    await node[1].trigger('click')
+    expect(wrapper.findAll('.n-checkbox--checked').length).toBe(2)
   })
 
-  it('should work with `click line to checked when there is children data`', async () => {
+  it('should work with `click line to checked when checkOnClick is function`', async () => {
+    function checkOnClick (node: TreeOption): boolean {
+      return node.label === '1-1'
+    }
+
     const wrapper = mount(NTree, {
       props: {
         expandOnClick: true,
+        checkOnClick,
         cascade: true,
         checkable: true,
         data: [
@@ -529,6 +539,9 @@ describe('n-tree', () => {
     expect(wrapper.findAll('.n-checkbox--checked').length).toBe(0)
     const childNode = wrapper.findAll('.n-tree-node-content')
     await childNode[1].trigger('click')
+    expect(wrapper.findAll('.n-checkbox--checked').length).toBe(1)
+    expect(wrapper.findAll('.n-checkbox--indeterminate').length).toBe(1)
+    await childNode[2].trigger('click')
     expect(wrapper.findAll('.n-checkbox--checked').length).toBe(1)
     expect(wrapper.findAll('.n-checkbox--indeterminate').length).toBe(1)
   })

--- a/src/tree/tests/Tree.spec.ts
+++ b/src/tree/tests/Tree.spec.ts
@@ -450,4 +450,86 @@ describe('n-tree', () => {
     await node[0].trigger('click')
     expect(wrapper.findAll('.n-tree-node--selected').length).toBe(2)
   })
+
+  it('should work with `click line to checked`', async () => {
+    const wrapper = mount(NTree, {
+      props: {
+        cascade: true,
+        checkable: true,
+        data: [
+          {
+            label: '1',
+            key: '1'
+          },
+          {
+            label: '2',
+            key: '2'
+          },
+          {
+            label: '3',
+            key: '3'
+          }
+        ]
+      }
+    })
+    const node = wrapper.findAll('.n-tree-node-content')
+    await node[0].trigger('click')
+    expect(wrapper.findAll('.n-checkbox--checked').length).toBe(1)
+    await node[0].trigger('click')
+    expect(wrapper.findAll('.n-checkbox--checked').length).toBe(0)
+    await node[0].trigger('click')
+    await node[1].trigger('click')
+    expect(wrapper.findAll('.n-checkbox--checked').length).toBe(2)
+  })
+
+  it('should work with `click line to checked when there is children data`', async () => {
+    const wrapper = mount(NTree, {
+      props: {
+        expandOnClick: true,
+        cascade: true,
+        checkable: true,
+        data: [
+          {
+            label: '1',
+            key: '1',
+            children: [
+              {
+                label: '1-1',
+                key: '1-1'
+              },
+              {
+                label: '1-2',
+                key: '1-2'
+              }
+            ]
+          },
+          {
+            label: '2',
+            key: '2',
+            children: [
+              {
+                label: '2-1',
+                key: '2-1'
+              },
+              {
+                label: '2-2',
+                key: '2-2'
+              }
+            ]
+          },
+          {
+            label: '3',
+            key: '3'
+          }
+        ]
+      }
+    })
+    const node = wrapper.findAll('.n-tree-node-content')
+    await node[0].trigger('click')
+    expect(wrapper.findAll('.n-checkbox--checked').length).toBe(0)
+    const childNode = wrapper.findAll('.n-tree-node-content')
+    await childNode[1].trigger('click')
+    expect(wrapper.findAll('.n-checkbox--checked').length).toBe(1)
+    expect(wrapper.findAll('.n-checkbox--indeterminate').length).toBe(1)
+  })
 })


### PR DESCRIPTION
### 改动原因

使用`tree`做功能管理，发现只能通过复选框进行选中，操作非常不便，可对比`checkbox`组件的操作。

### 改动说明：

- `tree` 组件在 `checkable = true` 下，点击`label`也可以进行选中
- `expand-on-click = true`下，点击整行也可以进行选中
- 当有`children`情况下，点击父项不会进行全选和取消，仅进行折叠和展开

已添加相关测试