### PR TITLE
fix(tag): missing bordered attribute in demo

### DIFF
--- a/src/tag/demos/enUS/bordered.demo.vue
+++ b/src/tag/demos/enUS/bordered.demo.vue
@@ -13,7 +13,7 @@
     <n-tag :bordered="false" type="warning">
       I'm Down
     </n-tag>
-    <n-tag type="error">
+    <n-tag :bordered="false" type="error">
       Yesterday
     </n-tag>
     <n-tag :bordered="false" type="info">


### PR DESCRIPTION
Fixed `bordered` reference for the tag demo. Not sure if that requires a changelog update.