### PR TITLE
fix(volar.d.ts): solve the code prompt…

### DIFF
--- a/CHANGELOG.en-US.md
+++ b/CHANGELOG.en-US.md
@@ -1,5 +1,13 @@
 # CHANGELOG
 
+## 2.30.5
+
+### Fixes
+
+- `volar.d.ts` remove `[key: string]: any` to solve the code prompt problem in `vscode`.
+
+### Feats
+
 ## 2.30.4
 
 ### Fixes

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -1,5 +1,13 @@
 # CHANGELOG
 
+## 2.30.5
+
+### Fixes
+
+- `volar.d.ts` 去除 `[key: string]: any` ,解决 `vscode` 中代码提示问题
+
+### Feats
+
 ## 2.30.4
 
 ### Fixes

--- a/volar.d.ts
+++ b/volar.d.ts
@@ -139,7 +139,6 @@ declare module 'vue' {
     NUploadFileList: typeof import('naive-ui')['NUploadFileList']
     NUploadTrigger: typeof import('naive-ui')['NUploadTrigger']
     NWatermark: typeof import('naive-ui')['NWatermark']
-    [key: string]: any
   }
 }
 export {}


### PR DESCRIPTION
### 改动原因

在`vscode`中开发，安装了`volar`插件，代码没有相关的提示。如图：
![image](https://user-images.githubusercontent.com/49502875/174256305-c3977c28-f68b-4fba-b205-ae0e5d39aa71.png)

### 改动说明

 根据代码提示定位，是由于`volar.d.ts`文件底部的`[key: string]: any`导致。所以将这段代码删除。
 删除后代码提示如图
![image](https://user-images.githubusercontent.com/49502875/174256642-475f1d2c-c077-4dcf-ac77-2ed4123e8803.png)
