### PR TITLE
feat(tree):  adds `check-on-click` prop

### DIFF
--- a/CHANGELOG.en-US.md
+++ b/CHANGELOG.en-US.md
@@ -1,5 +1,13 @@
 # CHANGELOG
 
+## NEXT_VERSION
+
+### Fixes
+
+### Feats
+
+- `n-tree` adds `check-on-click` prop to control `checked` status
+
 ## 2.30.5
 
 ### Fixes

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -1,5 +1,13 @@
 # CHANGELOG
 
+## NEXT_VERSION
+
+### Fixes
+
+### Feats
+
+- `n-tree` 新增属性 `check-on-click` 来控制可选状态下的选中交互方式
+
 ## 2.30.5
 
 ### Fixes

--- a/src/tree/demos/enUS/index.demo-entry.md
+++ b/src/tree/demos/enUS/index.demo-entry.md
@@ -28,7 +28,7 @@ checkbox-placement.vue
 ### Tree Props
 
 | Name | Type | default | Description | Version |
-| --- | --- | --- | --- | --- |
+| --- | --- | --- | --- | --- | --- |
 | allow-checking-not-loaded | `boolean` | `false` | Whether to allow cascade checking on not loaded nodes. If you want to use this, you should know the `check-keys` may be incomplete. Also, you should aware about the consistency bewteen naive's checking logic and your backend's checking logic, especially when there are disabled nodes. | 2.28.1 |
 | allow-drop | `(info: { dropPosition: DropPosition, node: TreeOption, phase: 'drag' \| 'drop' }) => boolean` | A function that prohibit dropping inside leaf node. | Whether to allow dropping. |  |
 | block-line | `boolean` | `false` | Nodes spread out the whole row. |  |
@@ -48,6 +48,7 @@ checkbox-placement.vue
 | draggable | `boolean` | `false` | Whether it can be dragged. |  |
 | expand-on-dragenter | `boolean` | `true` | Whether to expand nodes after dragenter. |  |
 | expand-on-click | `boolean` | `false` | Whether to expand or collapse nodes after click. | 2.29.1 |
+| check-on-click | `boolean | (node: TreeOption) => boolean` | `true` | Allow to click the `label` node to checked it when 'checkable = true' | NEXT_VERSION |
 | expanded-keys | `Array<string \| number>` | `undefined` | If set, expanded status will work in controlled manner. |  |
 | filter | `(pattern: string, node: TreeOption) => boolean` | A simple string based filter. | The function that filter tree nodes based on pattern. |  |
 | show-irrelevant-nodes | `boolean` | `true` | Whether to filter unmached nodes when tree is in filter mode. | 2.28.1 |

--- a/src/tree/demos/zhCN/index.demo-entry.md
+++ b/src/tree/demos/zhCN/index.demo-entry.md
@@ -32,7 +32,7 @@ scroll-debug.vue
 ### Tree Props
 
 | 名称 | 类型 | 默认值 | 说明 | 版本 |
-| --- | --- | --- | --- | --- |
+| --- | --- | --- | --- | --- | --- |
 | allow-checking-not-loaded | `boolean` | `false` | 是否允许级联勾选还没有完全加载的节点。如果你要用这个属性，请记住 `checked-keys` 可能是不完整的，并且请注意勾选行为和后端计算逻辑的一致性，尤其是有禁用节点的情况下 | 2.28.1 |
 | allow-drop | `(info: { dropPosition: DropPosition, node: TreeOption, phase: 'drag' \| 'drop' }) => boolean` | 一个不允许 drop 在叶节点内部的函数 | 是否允许 drop |  |
 | block-line | `boolean` | `false` | 节点整行撑开 |  |
@@ -52,6 +52,7 @@ scroll-debug.vue
 | draggable | `boolean` | `false` | 是否可拖拽 |  |
 | expand-on-dragenter | `boolean` | `true` | 是否在拖入后展开节点 |  |
 | expand-on-click | `boolean` | `false` | 是否在点击节点后展开或收缩节点 | 2.29.1 |
+| check-on-click | `boolean | (node: TreeOption) => boolean` | `true` | 是否允许点击`label`节点进行选中，仅在`checkable = true`下生效 | NEXT_VERSION |
 | expanded-keys | `Array<string \| number>` | `undefined` | 如果设定则展开受控 |  |
 | filter | `(pattern: string, node: TreeOption) => boolean` | 一个简单的字符串过滤算法 | 基于 pattern 指定过滤节点的函数 |  |
 | indeterminate-keys | `Array<string \| number>` | `undefined` | 部分选中选项的 key |  |

--- a/src/tree/src/Tree.tsx
+++ b/src/tree/src/Tree.tsx
@@ -54,7 +54,8 @@ import type {
   RenderPrefix,
   RenderSuffix,
   RenderSwitcherIcon,
-  TreeNodeProps
+  TreeNodeProps,
+  CheckOnClick
 } from './interface'
 import { treeInjectionKey } from './interface'
 import MotionWrapper from './MotionWrapper'
@@ -141,6 +142,10 @@ const treeProps = {
     default: true
   },
   expandOnClick: Boolean,
+  checkOnClick: {
+    type: [Boolean, Function] as PropType<CheckOnClick>,
+    default: true
+  },
   cancelable: {
     type: Boolean,
     default: true
@@ -1249,6 +1254,7 @@ export default defineComponent({
       blockLineRef: toRef(props, 'blockLine'),
       indentRef: toRef(props, 'indent'),
       cascadeRef: toRef(props, 'cascade'),
+      checkOnClickRef: toRef(props, 'checkOnClick'),
       checkboxPlacementRef: props.checkboxPlacement,
       droppingMouseNodeRef,
       droppingNodeParentRef,

--- a/src/tree/src/interface.ts
+++ b/src/tree/src/interface.ts
@@ -74,6 +74,8 @@ export interface InternalDropInfo {
 
 export type RenderSwitcherIcon = () => VNodeChild
 
+export type CheckOnClick = (option: TreeOption) => void
+
 export interface TreeInjection {
   loadingKeysRef: Ref<Set<Key>>
   highlightKeySetRef: Ref<Set<Key> | null>
@@ -110,6 +112,7 @@ export interface TreeInjection {
   multipleRef: Ref<boolean>
   checkboxPlacementRef: 'left' | 'right'
   internalTreeSelect: boolean
+  checkOnClickRef: Ref<boolean | CheckOnClick>
   handleSwitcherClick: (node: TreeNode<TreeOption>) => void
   handleSelect: (node: TreeNode<TreeOption>) => void
   handleCheck: (node: TreeNode<TreeOption>, checked: boolean) => void

--- a/src/tree/tests/Tree.spec.ts
+++ b/src/tree/tests/Tree.spec.ts
@@ -1,6 +1,6 @@
 import { mount } from '@vue/test-utils'
 import { nextTick } from 'vue'
-import { NTree } from '../index'
+import { NTree, TreeOption } from '../index'
 
 describe('n-tree', () => {
   it('should work with import on demand', () => {
@@ -449,5 +449,100 @@ describe('n-tree', () => {
     await wrapper.setProps({ multiple: true })
     await node[0].trigger('click')
     expect(wrapper.findAll('.n-tree-node--selected').length).toBe(2)
+  })
+
+  it('should work with `click line to checked`', async () => {
+    const wrapper = mount(NTree, {
+      props: {
+        cascade: true,
+        checkable: true,
+        data: [
+          {
+            label: '1',
+            key: '1'
+          },
+          {
+            label: '2',
+            key: '2'
+          },
+          {
+            label: '3',
+            key: '3'
+          }
+        ]
+      }
+    })
+    const node = wrapper.findAll('.n-tree-node-content')
+    await node[0].trigger('click')
+    expect(wrapper.findAll('.n-checkbox--checked').length).toBe(1)
+    await node[0].trigger('click')
+    expect(wrapper.findAll('.n-checkbox--checked').length).toBe(0)
+    await node[0].trigger('click')
+    await node[1].trigger('click')
+    expect(wrapper.findAll('.n-checkbox--checked').length).toBe(2)
+    await wrapper.setProps({ checkOnClick: false })
+    await node[0].trigger('click')
+    expect(wrapper.findAll('.n-checkbox--checked').length).toBe(2)
+    await node[1].trigger('click')
+    expect(wrapper.findAll('.n-checkbox--checked').length).toBe(2)
+  })
+
+  it('should work with `click line to checked when checkOnClick is function`', async () => {
+    function checkOnClick (node: TreeOption): boolean {
+      return node.label === '1-1'
+    }
+
+    const wrapper = mount(NTree, {
+      props: {
+        expandOnClick: true,
+        checkOnClick,
+        cascade: true,
+        checkable: true,
+        data: [
+          {
+            label: '1',
+            key: '1',
+            children: [
+              {
+                label: '1-1',
+                key: '1-1'
+              },
+              {
+                label: '1-2',
+                key: '1-2'
+              }
+            ]
+          },
+          {
+            label: '2',
+            key: '2',
+            children: [
+              {
+                label: '2-1',
+                key: '2-1'
+              },
+              {
+                label: '2-2',
+                key: '2-2'
+              }
+            ]
+          },
+          {
+            label: '3',
+            key: '3'
+          }
+        ]
+      }
+    })
+    const node = wrapper.findAll('.n-tree-node-content')
+    await node[0].trigger('click')
+    expect(wrapper.findAll('.n-checkbox--checked').length).toBe(0)
+    const childNode = wrapper.findAll('.n-tree-node-content')
+    await childNode[1].trigger('click')
+    expect(wrapper.findAll('.n-checkbox--checked').length).toBe(1)
+    expect(wrapper.findAll('.n-checkbox--indeterminate').length).toBe(1)
+    await childNode[2].trigger('click')
+    expect(wrapper.findAll('.n-checkbox--checked').length).toBe(1)
+    expect(wrapper.findAll('.n-checkbox--indeterminate').length).toBe(1)
   })
 })


### PR DESCRIPTION
### 改动原因

使用`tree`做功能管理，发现只能通过复选框进行选中，操作非常不便，可对比`checkbox`组件的操作。

### 改动说明：

- 新增属性`check-on-click`，在 `checkable = true` 下允许点击label节点进行选中
- 补充相关变更日志
- 补充文档说明
- 添加相关测试

修改后效果如下
![demo](https://user-images.githubusercontent.com/49502875/174519860-7d8d3ec9-5270-4f83-9474-cec734652138.gif)

