### PR TITLE
fix(color-picker): fix can't set alpha value correctly by hand

### DIFF
--- a/CHANGELOG.en-US.md
+++ b/CHANGELOG.en-US.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## NEXT_VERSION
+
+### Fixes
+- Fix `n-color-picker` can't set alpha value correctly by hand
+
 ## 2.30.5
 
 ### Fixes

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## NEXT_VERSION
+
+### Fixes
+- 修复 `n-color-picker` 手动输入alpha值时不生效的问题
+
 ## 2.30.5
 
 ### Fixes

--- a/src/color-picker/src/ColorInputUnit.tsx
+++ b/src/color-picker/src/ColorInputUnit.tsx
@@ -37,7 +37,7 @@ function normalizeHexaUnit (value: string): boolean {
 // 0 - 100%
 function normalizeAlphaUnit (value: string): number | false {
   if (/^\d{1,3}\.?\d*%$/.test(value.trim())) {
-    return Math.max(0, Math.min(parseInt(value), 100))
+    return Math.max(0, Math.min(parseInt(value) / 100, 100))
   }
   return false
 }


### PR DESCRIPTION
https://www.naiveui.com/zh-CN/os-theme/components/color-picker#basic.vue
手动输入alpha的值 总是为1的问题
发现是没有正确返回小数