### PR TITLE
fix(buttom): fix content placeholder incorrect when displayed as block., closes #3178

### DIFF
--- a/CHANGELOG.en-US.md
+++ b/CHANGELOG.en-US.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## NEXT_VERSION
+
+### Fixes
+
+- Fix `n-button` content placeholder incorrect when displayed as block, closes [#3178](https://github.com/TuSimple/naive-ui/issues/3178).
+
 ## 2.30.6
 
 ### Fixes

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## NEXT_VERSION
+
+### Fixes
+
+- 修复 `n-button` 显示为块级时内容占位不正确, 关闭 [#3178](https://github.com/TuSimple/naive-ui/issues/3178).
+
 ## 2.30.6
 
 ### Fixes

--- a/src/button/src/styles/index.cssr.ts
+++ b/src/button/src/styles/index.cssr.ts
@@ -212,6 +212,7 @@ export default c([
       display: flex;
       align-items: center;
       flex-wrap: nowrap;
+      min-width: 0;
     `, [
       c('~', [
         cE('icon', {


### PR DESCRIPTION
close #3178

![image](https://user-images.githubusercontent.com/33979706/175805694-7e1c4e34-f790-450a-aef0-11f192453109.png)
