### PR TITLE
fix(grid): correct spelling errors

### DIFF
--- a/src/grid/demos/zhCN/index.demo-entry.md
+++ b/src/grid/demos/zhCN/index.demo-entry.md
@@ -32,7 +32,7 @@ grid-basic-debug.vue
 
 | 名称 | 类型 | 默认值 | 说明 |
 | --- | --- | --- | --- |
-| offset | `number \| ResponsiveDescription` | `0` | 栅格左侧的间隔格数， |
+| offset | `number \| ResponsiveDescription` | `0` | 栅格左侧的间隔格数 |
 | span | `number \| ResponsiveDescription` | `1` | 栅格占据的列数，为 0 的时候会隐藏 |
 | suffix | `boolean` | `false` | 栅格后缀 |
 

--- a/src/grid/src/Grid.tsx
+++ b/src/grid/src/Grid.tsx
@@ -185,7 +185,7 @@ export default defineComponent({
           if (clonedNode.props) {
             clonedNode.props.privateShow = false
           } else {
-            clonedNode.props = { pirvateShow: false }
+            clonedNode.props = { privateShow: false }
           }
           childrenAndRawSpan.push({
             child: clonedNode,


### PR DESCRIPTION
Modify the wrong spelling of the variable name. Since there is a problem here, it means that there may be places that are not covered by the test case