### PR TITLE
fix(grid): correct spelling

### DIFF
--- a/src/grid/src/Grid.tsx
+++ b/src/grid/src/Grid.tsx
@@ -185,7 +185,7 @@ export default defineComponent({
           if (clonedNode.props) {
             clonedNode.props.privateShow = false
           } else {
-            clonedNode.props = { pirvateShow: false }
+            clonedNode.props = { privateShow: false }
           }
           childrenAndRawSpan.push({
             child: clonedNode,


### PR DESCRIPTION
Modify the wrong spelling of the variable name. Since there is a problem here, it means that there may be places that are not covered by the test case