### PR TITLE
chore: use `cz-git` commitizen adapter

### DIFF
--- a/package.json
+++ b/package.json
@@ -99,6 +99,7 @@
     "codesandbox": "^2.2.3",
     "cross-env": "^7.0.3",
     "cssnano": "^5.1.7",
+    "cz-git": "^1.3.8",
     "deepmerge": "^4.2.2",
     "esbuild": "0.14.42",
     "eslint": "^8.13.0",
@@ -163,6 +164,12 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/TuSimple/naive-ui"
+  },
+  "config": {
+    "commitizen": {
+      "path": "node_modules/cz-git",
+      "czConfig": "./scripts/commitizen.js"
+    }
   },
   "keywords": [
     "naive-ui",

--- a/scripts/commitizen.js
+++ b/scripts/commitizen.js
@@ -1,0 +1,28 @@
+'use strict'
+
+const { execSync } = require('child_process')
+const fg = require('fast-glob')
+
+const components = fg
+  .sync('*', { cwd: 'src', onlyDirectories: true })
+  .map((name) => name.replace(/^_/, ''))
+
+// precomputed scope
+const scopeComplete = execSync('git status --porcelain || true')
+  .toString()
+  .trim()
+  .split('\n')
+  .find((r) => ~r.indexOf('M  '))
+  ?.replace(/(\/)/g, '%%')
+  ?.match(/src%%((\w|-)*)/)?.[1]
+  ?.replace(/^_/, '')
+
+/** @type {import('cz-git').CommitizenGitOptions} */
+module.exports = {
+  scopes: ['build', 'demo', 'playground', 'script', ...components],
+  customScopesAlign: !scopeComplete ? 'top' : 'bottom',
+  defaultScope: scopeComplete,
+  maxHeaderLength: 100,
+  allowEmptyIssuePrefixs: false,
+  allowCustomIssuePrefixs: false
+}


### PR DESCRIPTION
<!--
!!! Please read the following content if this is your first pull request !!!

1. If you are working on docs, please set `docs` branch as the target branch.
2. If you are working on bug fixes or new features, please set `main` branch as the target branch.

For people who are working on 2, please add changelog to `CHANGELOG.zh-CN.md` & `CHANGELOG.en-US.md` in the PR. You need to add changelog to both files. You can use English in both file. The develop team will translate it later.

About docs & changelog's format and other tips, see in `CONTRIBUTING.md`.
-->
<!--
!!! 如果这是你第一次提交 PR，请阅读下面的内容 !!!

1. 如果你在修改文档，请提交到 `docs` 分支
2. 如果你在修复 Bug 或者开发新的特性，请提交到 `main` 分支

对于进行工作 2 的人，请在 `CHANGELOG.zh-CN.md` & `CHANGELOG.en-US.md` 中添加变更日志，你需要在两个文件中都添加变更日志。你可以只使用中文，开发团队会在之后进行翻译。

关于文档和变更日志的格式以及其他的帮助信息，请参考 `CONTRIBUTING.md`。
-->

Hi, I am the author of `cz-git`, I have checked the commit message of the project, I think it can be help maintainers who use commitizen CLI.
github: https://github.com/Zhengqbbb/cz-git
website | guide: https://cz-git.qbenben.com
中文文档: https://cz-git.qbenben.com/zh/

- **Friendly**: Supports search and selection on the command line, reducing spelling errors.
- **Lightweight**: Zero dependencies (1.5MB)
- **Highly Customizable**: The behavior of the CLI can be customized as project needed.

![demo](https://user-images.githubusercontent.com/40693636/176080491-df913fbe-e914-4464-ac0a-e46aaede5e24.gif)

### Feature
Use the `git status` command to get the component name matched in the stag modification, and automatically pin the component name at the top in the scope list

![demo](https://user-images.githubusercontent.com/40693636/176080995-e2f8d5f6-f620-4ab0-82f2-b89db2bf77e5.gif)
