### PR TITLE
fix(upload): accept `file.thumbnailUrl`

### DIFF
--- a/src/upload/src/UploadFile.tsx
+++ b/src/upload/src/UploadFile.tsx
@@ -228,7 +228,8 @@ export default defineComponent({
             {{ default: () => documentIcon }}
           </NBaseIcon>
         </span>
-      ) : (file.url || this.thumbnailUrl) && file.status !== 'error' ? (
+      ) : (file.url || this.thumbnailUrl || file.thumbnailUrl) &&
+        file.status !== 'error' ? (
         <a
           rel="noopener noreferer"
           target="_blank"
@@ -254,13 +255,13 @@ export default defineComponent({
             />
           )}
         </a>
-      ) : (
+          ) : (
         <span class={`${clsPrefix}-upload-file-info__thumbnail`}>
           <NBaseIcon clsPrefix={clsPrefix}>
             {{ default: () => imageIcon }}
           </NBaseIcon>
         </span>
-      )
+          )
     } else {
       icon = (
         <span class={`${clsPrefix}-upload-file-info__thumbnail`}>


### PR DESCRIPTION
## Context
After the upload is done, the image will be transferred to an oss url, which will be stored in the backend database.

And when the users want to review these images on some other day, frontend will fetch those urls from backend and refill the url values in `file.thumbnailUrl`.

In this case, `<UploadFile />` will failed to display thumbnails, because the code can't go into the right code path

## Solution

Since the thumbnail image src accepts `this.thumbnailUrl || file.thumbnailUrl || file.url`, sure the code path should accept `file.thumbnailUrl` too.

So, add `file.thumbnailUrl`
