### PR TITLE
test: done style to async style

### DIFF
--- a/src/loading-bar/tests/LoadingBar.spec.tsx
+++ b/src/loading-bar/tests/LoadingBar.spec.tsx
@@ -1,5 +1,6 @@
 import { mount } from '@vue/test-utils'
 import { defineComponent, h } from 'vue'
+import { sleep } from 'seemly'
 import { NLoadingBarProvider, useLoadingBar } from '../index'
 
 const Provider = defineComponent({
@@ -13,7 +14,7 @@ describe('n-loading-bar', () => {
     mount(NLoadingBarProvider)
   })
 
-  it('should have start type', (done) => {
+  it('should have start type', async () => {
     const Test = defineComponent({
       setup () {
         const loadingBar = useLoadingBar()
@@ -26,14 +27,12 @@ describe('n-loading-bar', () => {
     const wrapper = mount(() => (
       <Provider>{{ default: () => <Test /> }}</Provider>
     ))
-    setTimeout(() => {
-      expect(document.querySelector('.n-loading-bar')).not.toEqual(null)
-      wrapper.unmount()
-      done()
-    }, 0)
+    await sleep(0)
+    expect(document.querySelector('.n-loading-bar')).not.toEqual(null)
+    wrapper.unmount()
   })
 
-  it('should have finish type', (done) => {
+  it('should have finish type', async () => {
     const Test = defineComponent({
       setup () {
         const loadingBar = useLoadingBar()
@@ -49,13 +48,11 @@ describe('n-loading-bar', () => {
     const wrapper = mount(() => (
       <Provider>{{ default: () => <Test /> }}</Provider>
     ))
-    setTimeout(() => {
-      expect(document.querySelector('.n-loading-bar--finishing')).not.toEqual(
-        null
-      )
-      wrapper.unmount()
-      done()
-    }, 0)
+    await sleep(0)
+    expect(document.querySelector('.n-loading-bar--finishing')).not.toEqual(
+      null
+    )
+    wrapper.unmount()
   })
 
   it('should have error type', () => {
@@ -77,7 +74,7 @@ describe('n-loading-bar', () => {
     }, 0)
   })
 
-  it('should have loadingBarStyle prop', (done) => {
+  it('should have loadingBarStyle prop', async () => {
     const Test = defineComponent({
       setup () {
         const loadingBar = useLoadingBar()
@@ -100,12 +97,10 @@ describe('n-loading-bar', () => {
         default: () => <Test />
       }
     })
-    setTimeout(() => {
-      expect(
-        document.querySelector('.n-loading-bar--error')?.getAttribute('style')
-      ).toContain('height: 5px;')
-      wrapper.unmount()
-      done()
-    }, 0)
+    await sleep(0)
+    expect(
+      document.querySelector('.n-loading-bar--error')?.getAttribute('style')
+    ).toContain('height: 5px;')
+    wrapper.unmount()
   })
 })

--- a/src/message/tests/Message.spec.tsx
+++ b/src/message/tests/Message.spec.tsx
@@ -1,5 +1,6 @@
 import { mount } from '@vue/test-utils'
 import { defineComponent, h, nextTick } from 'vue'
+import { sleep } from 'seemly'
 import { NMessageProvider, useMessage } from '../index'
 
 const Provider = defineComponent({
@@ -35,7 +36,7 @@ describe('n-message', () => {
     ))
     wrapper.unmount()
   })
-  it('should work with showIcon', (done) => {
+  it('should work with showIcon', async () => {
     const Test = defineComponent({
       setup () {
         const message = useMessage()
@@ -53,18 +54,16 @@ describe('n-message', () => {
       <NoMaxProvider>{{ default: () => <Test /> }}</NoMaxProvider>
     ))
 
-    void nextTick(() => {
-      expect(document.querySelectorAll('.n-message__icon').length).toBe(1)
-      expect(document.querySelectorAll('.n-message').length).toBe(2)
+    await nextTick()
+    expect(document.querySelectorAll('.n-message__icon').length).toBe(1)
+    expect(document.querySelectorAll('.n-message').length).toBe(2)
 
-      wrapper.unmount()
-      done()
-    })
+    wrapper.unmount()
   })
 })
 
 describe('message-provider', () => {
-  it('props.max', (done) => {
+  it('props.max', async () => {
     const Test = defineComponent({
       setup () {
         const message = useMessage()
@@ -85,13 +84,12 @@ describe('message-provider', () => {
         default: () => <Test />
       }
     })
-    void nextTick(() => {
-      expect(document.querySelectorAll('.n-message').length).toBe(2)
-      wrapper.unmount()
-      done()
-    })
+    await nextTick()
+
+    expect(document.querySelectorAll('.n-message').length).toBe(2)
+    wrapper.unmount()
   })
-  it('props.duration', (done) => {
+  it('props.duration', async () => {
     const Test = defineComponent({
       setup () {
         const message = useMessage()
@@ -109,18 +107,14 @@ describe('message-provider', () => {
         default: () => <Test />
       }
     })
-    void nextTick(() => {
-      setTimeout(() => {
-        expect(document.querySelector('.n-message')).not.toEqual(null)
-      }, 500)
-      setTimeout(() => {
-        expect(document.querySelector('.n-message')).toBe(null)
-        wrapper.unmount()
-        done()
-      }, 1200)
-    })
+    await nextTick()
+    await sleep(500)
+    expect(document.querySelector('.n-message')).not.toEqual(null)
+    await sleep(1200)
+    expect(document.querySelector('.n-message')).toBe(null)
+    wrapper.unmount()
   })
-  it('props.closable', (done) => {
+  it('props.closable', async () => {
     const Test = defineComponent({
       setup () {
         const message = useMessage()
@@ -138,14 +132,12 @@ describe('message-provider', () => {
         default: () => <Test />
       }
     })
-    void nextTick(() => {
-      expect(document.querySelector('.n-message__close')).not.toBe(null)
-      wrapper.unmount()
-      done()
-    })
+    await nextTick()
+    expect(document.querySelector('.n-message__close')).not.toBe(null)
+    wrapper.unmount()
   })
 
-  it('props.container-style', (done) => {
+  it('props.container-style', async () => {
     const Test = defineComponent({
       setup () {
         const message = useMessage()
@@ -163,14 +155,10 @@ describe('message-provider', () => {
         default: () => <Test />
       }
     })
-    void nextTick(() => {
-      const container = document.querySelector('.n-message-container')
-      expect(container).not.toBe(null)
-      expect((container as HTMLElement).style.cssText).toContain(
-        'padding: 24px'
-      )
-      wrapper.unmount()
-      done()
-    })
+    await nextTick()
+    const container = document.querySelector('.n-message-container')
+    expect(container).not.toBe(null)
+    expect((container as HTMLElement).style.cssText).toContain('padding: 24px')
+    wrapper.unmount()
   })
 })

--- a/src/notification/tests/Notification.spec.tsx
+++ b/src/notification/tests/Notification.spec.tsx
@@ -1,4 +1,5 @@
 import { mount } from '@vue/test-utils'
+import { sleep } from 'seemly'
 import { defineComponent, h, ref, Ref, nextTick, onMounted } from 'vue'
 import {
   NNotificationProvider,
@@ -38,7 +39,7 @@ describe('n-notification', () => {
     wrapper.unmount()
   })
 
-  it('can change content', (done) => {
+  it('can change content', async () => {
     const changeContent = jest.fn((nRef: Ref) => {
       nRef.value.content = 'change info'
     })
@@ -61,22 +62,19 @@ describe('n-notification', () => {
     const wrapper = mount(() => (
       <Provider>{{ default: () => <Test /> }}</Provider>
     ))
-    void nextTick(() => {
-      expect(
-        document.querySelector('.n-notification-main__content')?.textContent
-      ).toEqual('info')
-      setTimeout(() => {
-        expect(changeContent).toHaveBeenCalled()
-        expect(
-          document.querySelector('.n-notification-main__content')?.textContent
-        ).toEqual('change info')
-        wrapper.unmount()
-        done()
-      }, 1000)
-    })
+    await nextTick()
+    expect(
+      document.querySelector('.n-notification-main__content')?.textContent
+    ).toEqual('info')
+    await sleep(1000)
+    expect(changeContent).toHaveBeenCalled()
+    expect(
+      document.querySelector('.n-notification-main__content')?.textContent
+    ).toEqual('change info')
+    wrapper.unmount()
   })
 
-  it('should work with duration', (done) => {
+  it('should work with duration', async () => {
     const Test = defineComponent({
       setup () {
         const notification = useNotification()
@@ -93,21 +91,17 @@ describe('n-notification', () => {
     const wrapper = mount(() => (
       <Provider>{{ default: () => <Test /> }}</Provider>
     ))
-    void nextTick(() => {
-      setTimeout(() => {
-        expect(document.querySelector('.n-notification')).not.toEqual(null)
-      }, 500)
-      setTimeout(() => {
-        expect(document.querySelector('.n-notification')).toBe(null)
-        wrapper.unmount()
-        done()
-      }, 1200)
-    })
+    await nextTick()
+    await sleep(500)
+    expect(document.querySelector('.n-notification')).not.toEqual(null)
+    await sleep(1200)
+    expect(document.querySelector('.n-notification')).toBe(null)
+    wrapper.unmount()
   })
 })
 
 describe('notification-provider', () => {
-  it('props.max', (done) => {
+  it('props.max', async () => {
     const Test = defineComponent({
       setup () {
         const notification = useNotification()
@@ -138,11 +132,9 @@ describe('notification-provider', () => {
         default: () => <Test />
       }
     })
-    setTimeout(() => {
-      expect(document.querySelectorAll('.n-notification').length).toBe(2)
-      wrapper.unmount()
-      done()
-    })
+    await nextTick()
+    expect(document.querySelectorAll('.n-notification').length).toBe(2)
+    wrapper.unmount()
   })
   it('should work with `placement` prop', async () => {
     const Test = defineComponent({


### PR DESCRIPTION
Signed-off-by: Sepush <sepush@outlook.com>

prework of migrate to Vitest
because from Vitest v0.10.0, the callback style of declaring tests is deprecated. 
I rewrite all of them to use async/await functions.
https://vitest.dev/guide/migration.html#migrating-from-jest
![image](https://user-images.githubusercontent.com/39197136/182029418-3e8c7695-51d4-4cb9-97e3-817edf2fc7a6.png)

<!--
!!! Please read the following content if this is your first pull request !!!

1. If you are working on docs, please set `docs` branch as the target branch.
2. If you are working on bug fixes or new features, please set `main` branch as the target branch.

For people who are working on 2, please add changelog to `CHANGELOG.zh-CN.md` & `CHANGELOG.en-US.md` in the PR. You need to add changelog to both files. You can use English in both file. The develop team will translate it later.

About docs & changelog's format and other tips, see in `CONTRIBUTING.md`.
-->
<!--
!!! 如果这是你第一次提交 PR，请阅读下面的内容 !!!

1. 如果你在修改文档，请提交到 `docs` 分支
2. 如果你在修复 Bug 或者开发新的特性，请提交到 `main` 分支

对于进行工作 2 的人，请在 `CHANGELOG.zh-CN.md` & `CHANGELOG.en-US.md` 中添加变更日志，你需要在两个文件中都添加变更日志。你可以只使用中文，开发团队会在之后进行翻译。

关于文档和变更日志的格式以及其他的帮助信息，请参考 `CONTRIBUTING.md`。
-->
