### PR TITLE
Add `exports` field in package.json for ESM and CommonJS

### DIFF
--- a/CHANGELOG.en-US.md
+++ b/CHANGELOG.en-US.md
@@ -7,6 +7,7 @@
 - Fix `n-menu` extra not working in submenu, closes [#3390](https://github.com/TuSimple/naive-ui/issues/3390).
 - Fix `n-tree` can't expand node with `type='group'`, closes [#3388](https://github.com/TuSimple/naive-ui/issues/3388).
 - Fix `n-pagination`'s' `default-page-size` prop doesn't follows `page-sizes` prop, closes [#3369](https://github.com/TuSimple/naive-ui/issues/3369).
+- Added `exports` field in package.json [3410](https://github.com/TuSimple/naive-ui/pull/3410)
 
 ### Feats
 

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -7,6 +7,7 @@
 - 修复 `n-menu` extra 在 submenu 中无效，关闭 [#3390](https://github.com/TuSimple/naive-ui/issues/3390)
 - 修复 `n-tree` 在传入的节点数据中包含 `type='group'` 时无法展开，关闭 [#3388](https://github.com/TuSimple/naive-ui/issues/3388)
 - 修复 `n-pagination` 的 `default-page-size` 没有跟随 `page-sizes` prop，关闭 [#3369](https://github.com/TuSimple/naive-ui/issues/3369)
+- Added `exports` field in package.json [3410](https://github.com/TuSimple/naive-ui/pull/3410)
 
 ### Feats
 

--- a/package.json
+++ b/package.json
@@ -45,6 +45,12 @@
     "web-types.json",
     "README.md"
   ],
+  "exports": {
+    "." : {
+      "import": "./es/index.js",
+      "require": "./lib/index.js"
+    }
+  },
   "web-types": "./web-types.json",
   "lint-staged": {
     "*.js": [


### PR DESCRIPTION
Added the `exports` field in package.json.

This field is sometimes used by bundlers to to differentiate `import` from `require`. 