### PR TITLE
feat: popover增加默认max-width

### DIFF
--- a/CHANGELOG.en-US.md
+++ b/CHANGELOG.en-US.md
@@ -19,6 +19,7 @@
 - `n-list` adds `show-divider` prop.
 - `n-thing` adds `content-style` prop.
 - `n-thing` adds `description-style` prop.
+- `n-popover` popover add default max-width
 
 ## 2.32.1
 

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -19,6 +19,7 @@
 - `n-list` 新增 `show-divider` 属性
 - `n-thing` 新增 `content-style` 属性
 - `n-thing` 新增 `description-style` 属性
+- `n-popover` popover 组件增加默认最大宽度
 
 ## 2.32.1
 

--- a/src/popover/src/PopoverBody.tsx
+++ b/src/popover/src/PopoverBody.tsx
@@ -186,7 +186,8 @@ export default defineComponent({
           borderRadius,
           arrowHeight,
           arrowOffset,
-          arrowOffsetVertical
+          arrowOffsetVertical,
+          tooltipMaxwidth
         }
       } = themeRef.value
 
@@ -205,7 +206,8 @@ export default defineComponent({
         '--n-arrow-offset-vertical': arrowOffsetVertical,
         '--n-padding': padding,
         '--n-space': space,
-        '--n-space-arrow': spaceArrow
+        '--n-space-arrow': spaceArrow,
+        '--n-tooltip-max-width': tooltipMaxwidth
       }
     })
     const themeClassHandle = inlineThemeDisabled

--- a/src/popover/src/styles/index.cssr.ts
+++ b/src/popover/src/styles/index.cssr.ts
@@ -37,6 +37,9 @@ export default c([
     font-size: var(--n-font-size);
     color: var(--n-text-color);
     box-shadow: var(--n-box-shadow);
+    width: max-content;
+    width: intrinsic;
+    max-width: var(--n-tooltip-max-width);
   `, [
     c('>', [
       cB('scrollbar', `

--- a/src/popover/styles/_common.ts
+++ b/src/popover/styles/_common.ts
@@ -4,5 +4,6 @@ export default {
   arrowOffset: '10px',
   arrowOffsetVertical: '10px',
   arrowHeight: '6px',
-  padding: '8px 14px'
+  padding: '8px 14px',
+  tooltipMaxwidth: '250px'
 }


### PR DESCRIPTION
popover组件需要增加默认最大宽度。使用NDataTable组件是，某个元素内容过长，使用column.ellipsis.tooltip，会出现以下问题，所以建议有一个默认的popover的max-width
<img width="1086" alt="image" src="https://user-images.githubusercontent.com/31615692/182787941-95912c59-6065-42d5-bf01-92d320bd7fd8.png">
