### PR TITLE
textarea字数显示与输入文本重叠

### DIFF
--- a/CHANGELOG.en-US.md
+++ b/CHANGELOG.en-US.md
@@ -8,6 +8,7 @@
 - Fix `n-tree` can't expand node with `type='group'`, closes [#3388](https://github.com/TuSimple/naive-ui/issues/3388).
 - Fix `n-pagination`'s' `default-page-size` prop doesn't follows `page-sizes` prop, closes [#3369](https://github.com/TuSimple/naive-ui/issues/3369).
 - Added `exports` field in package.json [3410](https://github.com/TuSimple/naive-ui/pull/3410)
+- `n-input`'s count area may overflow with input text.
 
 ### Feats
 

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -8,7 +8,7 @@
 - 修复 `n-tree` 在传入的节点数据中包含 `type='group'` 时无法展开，关闭 [#3388](https://github.com/TuSimple/naive-ui/issues/3388)
 - 修复 `n-pagination` 的 `default-page-size` 没有跟随 `page-sizes` prop，关闭 [#3369](https://github.com/TuSimple/naive-ui/issues/3369)
 - Added `exports` field in package.json [3410](https://github.com/TuSimple/naive-ui/pull/3410)
-- `n-input` 字数与输入文本重叠
+- `n-input` 输入字数与输入文本重叠
 
 ### Feats
 

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -8,6 +8,7 @@
 - 修复 `n-tree` 在传入的节点数据中包含 `type='group'` 时无法展开，关闭 [#3388](https://github.com/TuSimple/naive-ui/issues/3388)
 - 修复 `n-pagination` 的 `default-page-size` 没有跟随 `page-sizes` prop，关闭 [#3369](https://github.com/TuSimple/naive-ui/issues/3369)
 - Added `exports` field in package.json [3410](https://github.com/TuSimple/naive-ui/pull/3410)
+- `n-input` 字数与输入文本重叠
 
 ### Feats
 

--- a/src/input/src/styles/input.cssr.ts
+++ b/src/input/src/styles/input.cssr.ts
@@ -162,6 +162,7 @@ export default cB('input', `
       position: absolute;
       right: var(--n-padding-right);
       bottom: var(--n-padding-vertical);
+      background-color: var(--n-color);
     `),
     cM('resizable', [
       cB('input-wrapper', `


### PR DESCRIPTION
<img width="883" alt="image" src="https://user-images.githubusercontent.com/31615692/183325665-f92adac0-1aa4-4aca-b8ff-16ddf193da4f.png">

「字数限制」区域与输入文本重叠了，需要给「字数限制」区域增加一个白色背景即可。
<img width="854" alt="image" src="https://user-images.githubusercontent.com/31615692/183325770-12880f85-a2a2-431f-b781-a5f2e0f4f164.png">
