### PR TITLE
docs(usage-sfc): Add typeRoots configuration to volar

### DIFF
--- a/demo/pages/docs/usage-sfc/zhCN/index.md
+++ b/demo/pages/docs/usage-sfc/zhCN/index.md
@@ -72,7 +72,11 @@ app.use(naive)
 {
   "compilerOptions": {
     // ...
-    "types": ["naive-ui/volar"]
+    "types": ["naive-ui/volar"],
+    "typeRoots": [
+      // ...
+      "./node_modules/@types/"
+    ]
   }
 }
 ```


### PR DESCRIPTION
为【在 SFC 中使用】一节的文档中添加一段tsconfig.json的配置。
对于一些typescript新手来说，如果没有设置typeRoots这块的配置，那么很可能在.vue文件中，无法使用组件库的一些属性类型提示。
