### PR TITLE
fix(input): scrollbar's themeOverrides configuration is not injected into the input

### DIFF
--- a/CHANGELOG.en-US.md
+++ b/CHANGELOG.en-US.md
@@ -10,6 +10,7 @@
 
 - Fix `n-image` zoom in & out locale text in `da-DK` `sv-SE`.
 - Fix `n-popover`'s `themeOverrides` property does not have the `Scrollbar` style configuration.
+- Fix `n-input`'s `themeOverrides` property does not have the `Scrollbar` style configuration.
 - Fix `n-anchor` can't activate link in the bottom of the page by click, closes [#7033](https://github.com/tusen-ai/naive-ui/issues/7033), closes [#6918](https://github.com/tusen-ai/naive-ui/issues/6918), [#6844](https://github.com/tusen-ai/naive-ui/issues/6844), [#6782](https://github.com/tusen-ai/naive-ui/issues/6782).
 - Fix `n-upload` component 'Non-function value encountered for default slot' warning.
 - Fix `n-input`'s `tabindex` property setting of `input-props` does not take effect.

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -10,6 +10,7 @@
 
 - 修复 `n-image` 放大缩小在 `da-DK` `sv-SE` 本地化的文案
 - 修复 `n-popover` 的 `themeOverrides` 属性没有 `Scrollbar` 样式配置
+- 修复 `n-input` 的 `themeOverrides` 属性没有 `Scrollbar` 样式配置
 - 修复 `n-anchor` 对页面底部的 link 无法通过点击激活，关闭 [#7033](https://github.com/tusen-ai/naive-ui/issues/7033)，关闭 [#6918](https://github.com/tusen-ai/naive-ui/issues/6918)、[#6844](https://github.com/tusen-ai/naive-ui/issues/6844)、[#6782](https://github.com/tusen-ai/naive-ui/issues/6782)
 - 修复 `n-upload` 组件 'Non-function value encountered for default slot' 警告
 - 修复 `n-input` 的 `input-props` 属性设置 `tabindex` 不生效的问题

--- a/src/input/src/Input.tsx
+++ b/src/input/src/Input.tsx
@@ -1157,6 +1157,8 @@ export default defineComponent({
               ref="textareaScrollbarInstRef"
               class={`${mergedClsPrefix}-input__textarea`}
               container={this.getTextareaScrollContainer}
+              theme={this.theme?.peers?.Scrollbar}
+              themeOverrides={this.themeOverrides?.peers?.Scrollbar}
               triggerDisplayManually
               useUnifiedContainer
               internalHoistYRail

--- a/src/input/styles/dark.ts
+++ b/src/input/styles/dark.ts
@@ -1,110 +1,118 @@
-import type { InputTheme } from './light'
+import type { ThemeCommonVars } from '../../_styles/common'
 import { changeColor } from 'seemly'
+import { scrollbarDark } from '../../_internal/scrollbar/styles'
+import { createTheme } from '../../_mixins'
 import { commonDark } from '../../_styles/common'
 import commonVariables from './_common'
 
-const inputDark: InputTheme = {
-  name: 'Input',
-  common: commonDark,
-  self(vars) {
-    const {
-      textColor2,
-      textColor3,
-      textColorDisabled,
-      primaryColor,
-      primaryColorHover,
-      inputColor,
-      inputColorDisabled,
-      warningColor,
-      warningColorHover,
-      errorColor,
-      errorColorHover,
-      borderRadius,
-      lineHeight,
-      fontSizeTiny,
-      fontSizeSmall,
-      fontSizeMedium,
-      fontSizeLarge,
-      heightTiny,
-      heightSmall,
-      heightMedium,
-      heightLarge,
-      clearColor,
-      clearColorHover,
-      clearColorPressed,
-      placeholderColor,
-      placeholderColorDisabled,
-      iconColor,
-      iconColorDisabled,
-      iconColorHover,
-      iconColorPressed,
-      fontWeight
-    } = vars
-    return {
-      ...commonVariables,
-      fontWeight,
-      countTextColorDisabled: textColorDisabled,
-      countTextColor: textColor3,
-      heightTiny,
-      heightSmall,
-      heightMedium,
-      heightLarge,
-      fontSizeTiny,
-      fontSizeSmall,
-      fontSizeMedium,
-      fontSizeLarge,
-      lineHeight,
-      lineHeightTextarea: lineHeight,
-      borderRadius,
-      iconSize: '16px',
-      groupLabelColor: inputColor,
-      textColor: textColor2,
-      textColorDisabled,
-      textDecorationColor: textColor2,
-      groupLabelTextColor: textColor2,
-      caretColor: primaryColor,
-      placeholderColor,
-      placeholderColorDisabled,
-      color: inputColor,
-      colorDisabled: inputColorDisabled,
-      colorFocus: changeColor(primaryColor, { alpha: 0.1 }),
-      groupLabelBorder: '1px solid #0000',
-      border: '1px solid #0000',
-      borderHover: `1px solid ${primaryColorHover}`,
-      borderDisabled: '1px solid #0000',
-      borderFocus: `1px solid ${primaryColorHover}`,
-      boxShadowFocus: `0 0 8px 0 ${changeColor(primaryColor, { alpha: 0.3 })}`,
-      loadingColor: primaryColor,
-      // warning
-      loadingColorWarning: warningColor,
-      borderWarning: `1px solid ${warningColor}`,
-      borderHoverWarning: `1px solid ${warningColorHover}`,
-      colorFocusWarning: changeColor(warningColor, { alpha: 0.1 }),
-      borderFocusWarning: `1px solid ${warningColorHover}`,
-      boxShadowFocusWarning: `0 0 8px 0 ${changeColor(warningColor, {
-        alpha: 0.3
-      })}`,
-      caretColorWarning: warningColor,
-      // error
-      loadingColorError: errorColor,
-      borderError: `1px solid ${errorColor}`,
-      borderHoverError: `1px solid ${errorColorHover}`,
-      colorFocusError: changeColor(errorColor, { alpha: 0.1 }),
-      borderFocusError: `1px solid ${errorColorHover}`,
-      boxShadowFocusError: `0 0 8px 0 ${changeColor(errorColor, {
-        alpha: 0.3
-      })}`,
-      caretColorError: errorColor,
-      clearColor,
-      clearColorHover,
-      clearColorPressed,
-      iconColor,
-      iconColorDisabled,
-      iconColorHover,
-      iconColorPressed,
-      suffixTextColor: textColor2
-    }
+function self(vars: ThemeCommonVars) {
+  const {
+    textColor2,
+    textColor3,
+    textColorDisabled,
+    primaryColor,
+    primaryColorHover,
+    inputColor,
+    inputColorDisabled,
+    warningColor,
+    warningColorHover,
+    errorColor,
+    errorColorHover,
+    borderRadius,
+    lineHeight,
+    fontSizeTiny,
+    fontSizeSmall,
+    fontSizeMedium,
+    fontSizeLarge,
+    heightTiny,
+    heightSmall,
+    heightMedium,
+    heightLarge,
+    clearColor,
+    clearColorHover,
+    clearColorPressed,
+    placeholderColor,
+    placeholderColorDisabled,
+    iconColor,
+    iconColorDisabled,
+    iconColorHover,
+    iconColorPressed,
+    fontWeight
+  } = vars
+  return {
+    ...commonVariables,
+    fontWeight,
+    countTextColorDisabled: textColorDisabled,
+    countTextColor: textColor3,
+    heightTiny,
+    heightSmall,
+    heightMedium,
+    heightLarge,
+    fontSizeTiny,
+    fontSizeSmall,
+    fontSizeMedium,
+    fontSizeLarge,
+    lineHeight,
+    lineHeightTextarea: lineHeight,
+    borderRadius,
+    iconSize: '16px',
+    groupLabelColor: inputColor,
+    textColor: textColor2,
+    textColorDisabled,
+    textDecorationColor: textColor2,
+    groupLabelTextColor: textColor2,
+    caretColor: primaryColor,
+    placeholderColor,
+    placeholderColorDisabled,
+    color: inputColor,
+    colorDisabled: inputColorDisabled,
+    colorFocus: changeColor(primaryColor, { alpha: 0.1 }),
+    groupLabelBorder: '1px solid #0000',
+    border: '1px solid #0000',
+    borderHover: `1px solid ${primaryColorHover}`,
+    borderDisabled: '1px solid #0000',
+    borderFocus: `1px solid ${primaryColorHover}`,
+    boxShadowFocus: `0 0 8px 0 ${changeColor(primaryColor, { alpha: 0.3 })}`,
+    loadingColor: primaryColor,
+    // warning
+    loadingColorWarning: warningColor,
+    borderWarning: `1px solid ${warningColor}`,
+    borderHoverWarning: `1px solid ${warningColorHover}`,
+    colorFocusWarning: changeColor(warningColor, { alpha: 0.1 }),
+    borderFocusWarning: `1px solid ${warningColorHover}`,
+    boxShadowFocusWarning: `0 0 8px 0 ${changeColor(warningColor, {
+      alpha: 0.3
+    })}`,
+    caretColorWarning: warningColor,
+    // error
+    loadingColorError: errorColor,
+    borderError: `1px solid ${errorColor}`,
+    borderHoverError: `1px solid ${errorColorHover}`,
+    colorFocusError: changeColor(errorColor, { alpha: 0.1 }),
+    borderFocusError: `1px solid ${errorColorHover}`,
+    boxShadowFocusError: `0 0 8px 0 ${changeColor(errorColor, {
+      alpha: 0.3
+    })}`,
+    caretColorError: errorColor,
+    clearColor,
+    clearColorHover,
+    clearColorPressed,
+    iconColor,
+    iconColorDisabled,
+    iconColorHover,
+    iconColorPressed,
+    suffixTextColor: textColor2
   }
 }
 
+const inputDark = createTheme({
+  name: 'Input',
+  common: commonDark,
+  peers: {
+    Scrollbar: scrollbarDark
+  },
+  self
+})
+
+export type InputThemeVars = ReturnType<typeof self>
 export default inputDark

--- a/src/input/styles/light.ts
+++ b/src/input/styles/light.ts
@@ -1,6 +1,7 @@
-import type { Theme } from '../../_mixins'
 import type { ThemeCommonVars } from '../../_styles/common'
 import { changeColor } from 'seemly'
+import { scrollbarLight } from '../../_internal/scrollbar/styles'
+import { createTheme } from '../../_mixins'
 import { commonLight } from '../../_styles/common'
 import commonVariables from './_common'
 
@@ -106,13 +107,15 @@ function self(vars: ThemeCommonVars) {
   }
 }
 
-export type InputThemeVars = ReturnType<typeof self>
-
-const inputLight: Theme<'Input', InputThemeVars> = {
+const inputLight = createTheme({
   name: 'Input',
   common: commonLight,
+  peers: {
+    Scrollbar: scrollbarLight
+  },
   self
-}
+})
 
-export default inputLight
+export type InputThemeVars = ReturnType<typeof self>
 export type InputTheme = typeof inputLight
+export default inputLight


### PR DESCRIPTION
Fix `n-input`'s `themeOverrides` property does not have the `Scrollbar` style configuration.

<!--
!!! Please read the following content if this is your first pull request !!!

1. If you are working on docs, please set `docs` branch as the target branch.
2. If you are working on bug fixes or new features, please set `main` branch as the target branch.

For people who are working on 2, please add changelog to `CHANGELOG.zh-CN.md` & `CHANGELOG.en-US.md` in the PR. You need to add changelog to both files. You can use English in both file. The develop team will translate it later.

About docs & changelog's format and other tips, see in `CONTRIBUTING.md`.
-->
<!--
!!! 如果这是你第一次提交 PR，请阅读下面的内容 !!!

1. 如果你在修改文档，请提交到 `docs` 分支
2. 如果你在修复 Bug 或者开发新的特性，请提交到 `main` 分支

对于进行工作 2 的人，请在 `CHANGELOG.zh-CN.md` & `CHANGELOG.en-US.md` 中添加变更日志，你需要在两个文件中都添加变更日志。你可以只使用中文，开发团队会在之后进行翻译。

关于文档和变更日志的格式以及其他的帮助信息，请参考 `CONTRIBUTING.md`。
-->
