### PR TITLE
fix(color-picker): black and white effect of trigger text is not obvious

### DIFF
--- a/CHANGELOG.en-US.md
+++ b/CHANGELOG.en-US.md
@@ -8,6 +8,7 @@
 
 ### Fixes
 
+- Fix `n-color-picker` black and white effect of text is not obvious, closes [#7074](https://github.com/tusen-ai/naive-ui/issues/7074).
 - Fix `n-image` zoom in & out locale text in `da-DK` `sv-SE`.
 - Fix `n-popover`'s `themeOverrides` property does not have the `Scrollbar` style configuration.
 - Fix `n-anchor` can't activate link in the bottom of the page by click, closes [#7033](https://github.com/tusen-ai/naive-ui/issues/7033), closes [#6918](https://github.com/tusen-ai/naive-ui/issues/6918), [#6844](https://github.com/tusen-ai/naive-ui/issues/6844), [#6782](https://github.com/tusen-ai/naive-ui/issues/6782).

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -8,6 +8,7 @@
 
 ### Fixes
 
+- 修复 `n-color-picker` 的 trigger 文字黑白颜色效果不明显问题，关闭 [#7074](https://github.com/tusen-ai/naive-ui/issues/7074)
 - 修复 `n-image` 放大缩小在 `da-DK` `sv-SE` 本地化的文案
 - 修复 `n-popover` 的 `themeOverrides` 属性没有 `Scrollbar` 样式配置
 - 修复 `n-anchor` 对页面底部的 link 无法通过点击激活，关闭 [#7033](https://github.com/tusen-ai/naive-ui/issues/7033)，关闭 [#6918](https://github.com/tusen-ai/naive-ui/issues/6918)、[#6844](https://github.com/tusen-ai/naive-ui/issues/6844)、[#6782](https://github.com/tusen-ai/naive-ui/issues/6782)

--- a/src/color-picker/src/ColorPickerTrigger.tsx
+++ b/src/color-picker/src/ColorPickerTrigger.tsx
@@ -1,6 +1,7 @@
 import { type HSLA, toHslaString } from 'seemly'
 import { defineComponent, h, inject, type PropType, type SlotsType } from 'vue'
 import { colorPickerInjectionKey } from './context'
+import { getWCAGContrast } from './utils'
 
 export default defineComponent({
   name: 'ColorPickerTrigger',
@@ -53,7 +54,7 @@ export default defineComponent({
               <div
                 class={`${clsPrefix}-color-picker-trigger__value`}
                 style={{
-                  color: hsla[2] > 50 || hsla[3] < 0.5 ? 'black' : 'white'
+                  color: getWCAGContrast(hsla) ? 'white' : 'black'
                 }}
               >
                 {renderLabel ? renderLabel(value) : value}


### PR DESCRIPTION
The brightness algorithm is replaced with [WCAG 2.1](https://www.w3.org/TR/WCAG21) AA for comparison, which is more accurate and intuitive than the previous brightness calculation.

close #7074 

<!--
!!! Please read the following content if this is your first pull request !!!

1. If you are working on docs, please set `docs` branch as the target branch.
2. If you are working on bug fixes or new features, please set `main` branch as the target branch.

For people who are working on 2, please add changelog to `CHANGELOG.zh-CN.md` & `CHANGELOG.en-US.md` in the PR. You need to add changelog to both files. You can use English in both file. The develop team will translate it later.

About docs & changelog's format and other tips, see in `CONTRIBUTING.md`.
-->
<!--
!!! 如果这是你第一次提交 PR，请阅读下面的内容 !!!

1. 如果你在修改文档，请提交到 `docs` 分支
2. 如果你在修复 Bug 或者开发新的特性，请提交到 `main` 分支

对于进行工作 2 的人，请在 `CHANGELOG.zh-CN.md` & `CHANGELOG.en-US.md` 中添加变更日志，你需要在两个文件中都添加变更日志。你可以只使用中文，开发团队会在之后进行翻译。

关于文档和变更日志的格式以及其他的帮助信息，请参考 `CONTRIBUTING.md`。
-->
