### PR TITLE
fix(types): onClick type define from `MouseEvent` to `PointerEvent`

### DIFF
--- a/src/image/src/Image.tsx
+++ b/src/image/src/Image.tsx
@@ -137,7 +137,7 @@ export default defineComponent({
       })
     })
 
-    function onImgClick(e: MouseEvent) {
+    function onImgClick(e: PointerEvent) {
       exposedMethods.showPreview()
       props.imgProps?.onClick?.(e)
     }
@@ -160,7 +160,7 @@ export default defineComponent({
       showError: showErrorRef,
       shouldStartLoading: shouldStartLoadingRef,
       loaded: loadedRef,
-      mergedOnClick: (e: MouseEvent) => {
+      mergedOnClick: (e: PointerEvent) => {
         onImgClick(e)
       },
       onPreviewClose,

--- a/src/tree/src/TreeNode.tsx
+++ b/src/tree/src/TreeNode.tsx
@@ -174,7 +174,7 @@ const TreeNode = defineComponent({
       }
     }
 
-    function handleNodeClick(e: MouseEvent): void {
+    function handleNodeClick(e: PointerEvent): void {
       if (happensIn(e, 'checkbox') || happensIn(e, 'switcher'))
         return
       if (!disabledRef.value) {
@@ -214,13 +214,13 @@ const TreeNode = defineComponent({
       resolvedNodePropsRef.value?.onClick?.(e)
     }
 
-    function handleContentClick(e: MouseEvent): void {
+    function handleContentClick(e: PointerEvent): void {
       if (blockLineRef.value)
         return
       handleNodeClick(e)
     }
 
-    function handleLineClick(e: MouseEvent): void {
+    function handleLineClick(e: PointerEvent): void {
       if (!blockLineRef.value)
         return
       handleNodeClick(e)

--- a/src/tree/src/TreeNodeContent.tsx
+++ b/src/tree/src/TreeNodeContent.tsx
@@ -19,7 +19,7 @@ export default defineComponent({
     disabled: Boolean,
     checked: Boolean,
     selected: Boolean,
-    onClick: Function as PropType<(e: MouseEvent) => void>,
+    onClick: Function as PropType<(e: PointerEvent) => void>,
     onDragstart: Function as PropType<(e: DragEvent) => void>,
     tmNode: {
       type: Object as PropType<TmNode>,
@@ -31,12 +31,12 @@ export default defineComponent({
     const { renderLabelRef, renderPrefixRef, renderSuffixRef, labelFieldRef }
       = inject(treeInjectionKey)!
     const selfRef = ref<HTMLElement | null>(null)
-    function doClick(e: MouseEvent): void {
+    function doClick(e: PointerEvent): void {
       const { onClick } = props
       if (onClick)
         onClick(e)
     }
-    function handleClick(e: MouseEvent): void {
+    function handleClick(e: PointerEvent): void {
       doClick(e)
     }
     return {


### PR DESCRIPTION
`onClick` type define from `MouseEvent` to `PointerEvent`since Vue@3.5.21

ref https://github.com/vuejs/core/pull/13804
