### PR TITLE
doc: typo

### DIFF
--- a/src/button/demos/zhCN/popover.demo.vue
+++ b/src/button/demos/zhCN/popover.demo.vue
@@ -1,7 +1,7 @@
 <markdown>
 # 配合 Popover 的特殊情况
 
-原生的 disabled 的 button 不会触发鼠标，因此 `n-popover` 无法监听到相关的事件。如果你需要在这种情况下使用，可以使用 `tag` 属性来调整 button 的行为。
+disabled 的原生 button 不会触发部分鼠标事件，因此 `n-popover` 无法监听到相关的事件。如果你需要在这种情况下使用，可以使用 `tag` 属性来调整 button 的行为。
 </markdown>
 
 <template>


### PR DESCRIPTION
<!--
!!! Please read the following content if this is your first pull request !!!

1. If you are working on docs, please set `docs` branch as the target branch.
2. If you are working on bug fixes or new features, please set `main` branch as the target branch.

For people who are working on 2, please add changelog to `CHANGELOG.zh-CN.md` & `CHANGELOG.en-US.md` in the PR. You need to add changelog to both files. You can use English in both file. The develop team will translate it later.

About docs & changelog's format and other tips, see in `CONTRIBUTING.md`.
-->
<!--
!!! 如果这是你第一次提交 PR，请阅读下面的内容 !!!

1. 如果你在修改文档，请提交到 `docs` 分支
2. 如果你在修复 Bug 或者开发新的特性，请提交到 `main` 分支

对于进行工作 2 的人，请在 `CHANGELOG.zh-CN.md` & `CHANGELOG.en-US.md` 中添加变更日志，你需要在两个文件中都添加变更日志。你可以只使用中文，开发团队会在之后进行翻译。

关于文档和变更日志的格式以及其他的帮助信息，请参考 `CONTRIBUTING.md`。
-->
<img width="1062" height="520" alt="image" src="https://github.com/user-attachments/assets/8a5eb0f1-d18c-4cf5-ab6c-4db8a9f8a0ae" />

这里忘记说”事件“了。
英文原文：The native disabled button won't trigger some mouse events so `n-popover` can't listen to it.
原翻译：原生的 disabled 的 button 不会触发鼠标，因此 `n-popover` 无法监听到相关的事件。
现翻译：disabled 的原生 button 不会触发部分鼠标事件，因此 `n-popover` 无法监听到相关的事件。