### PR TITLE
fix(tsToJs): add tsconfigRaw to preserve icon import statements

### DIFF
--- a/build/utils/tsToJs.ts
+++ b/build/utils/tsToJs.ts
@@ -13,7 +13,13 @@ export function tsToJs(content: string | null): string {
     loader: 'ts',
     minify: false,
     minifyWhitespace: false,
-    charset: 'utf8'
+    charset: 'utf8',
+    // to keep the icon `import` statement in script setup
+    tsconfigRaw: `{
+      "compilerOptions": {
+        "verbatimModuleSyntax": true
+      }
+    }`
   })
   return code.trim().replace(/__blankline;/g, '')
 }


### PR DESCRIPTION
fix https://github.com/tusen-ai/naive-ui/issues/7306

前段时间我们的文档示例代码从 `options` 写法重构到了 `script setup`
之前对于 icon 的 `import` 我们在 `script` 里有显式的引用
```vue
<script lang="ts">
import { GameController, GameControllerOutline } from '@vicons/ionicons5'
import { defineComponent } from 'vue'

export default defineComponent({
  components: {
    GameController,
    GameControllerOutline
  },
  setup() {
    return {
      GameController
    }
  }
})
</script>

<template>
  <n-icon size="40">
    <GameControllerOutline />
  </n-icon>
  <n-icon size="40" color="#0e7a0d">
    <GameController />
  </n-icon>
  <n-icon size="40" :component="GameController" />
</template>
```

```vue
<script lang="ts" setup>
import { GameController, GameControllerOutline } from '@vicons/ionicons5'
</script>

<template>
  <n-icon size="40">
    <GameControllerOutline />
  </n-icon>
  <n-icon size="40" color="#0e7a0d">
    <GameController />
  </n-icon>
  <n-icon size="40" :component="GameController" />
</template>
```
迁移后只在`template`里存在引用 而我们的给 `esbuild` 的转换的只有 `script` 部分这会导致 `esbuild` 认为这是无用的代码做一些死代码消除，可以通过编译选项 [verbatimModuleSyntax](https://www.typescriptlang.org/tsconfig/#verbatimModuleSyntax) https://esbuild.github.io/content-types/#tsconfig-json 控制这一行为


