### PR TITLE
Fix typo in highlight props documentation

### DIFF
--- a/src/highlight/demos/enUS/index.demo-entry.md
+++ b/src/highlight/demos/enUS/index.demo-entry.md
@@ -19,7 +19,7 @@ component.vue
 
 | Name | Type | Default | Description | Version |
 | --- | --- | --- | --- | --- |
-| auto-espace | `boolean` | `true` | Whether to escape `patterns` automatically. By default, elements in `patterns` will be converted into regular expressions for matching, and this process includes automatic escaping, so that the regular expressions will match the literal content of the elements. For example, `\(` will match `\(`. If you need the n-highlight component to match using regular expressions constructed from the elements in `patterns` themselves (e.g., `\(` matches `(`), you can set this to false. If you do not understand these details, do not change this setting. | 2.40.0 |
+| auto-escape | `boolean` | `true` | Whether to escape `patterns` automatically. By default, elements in `patterns` will be converted into regular expressions for matching, and this process includes automatic escaping, so that the regular expressions will match the literal content of the elements. For example, `\(` will match `\(`. If you need the n-highlight component to match using regular expressions constructed from the elements in `patterns` themselves (e.g., `\(` matches `(`), you can set this to false. If you do not understand these details, do not change this setting. | 2.40.0 |
 | case-sensitive | `boolean` | `false` | Case sensitive or not. | 2.40.0 |
 | highlight-class | `string` | `undefined` | Class name of the highlight content. | 2.40.0 |
 | highlight-style | `Object \| string` | `undefined` | Style of the highlight content. | 2.40.0 |


### PR DESCRIPTION
This pull request makes a small but important correction to the documentation for the `n-highlight` component. Specifically, it fixes a typo in the property name to ensure accuracy and consistency.

- Documentation correction:
  * Fixed the property name from `auto-espace` to `auto-escape` in the demo entry table for the `n-highlight` component to accurately reflect the intended option.