### PR TITLE
docs: 修复 Dropdown 手动定位示例中 Esc 键无法关闭的问题

### DIFF
--- a/src/dropdown/demos/enUS/manual-position.demo.vue
+++ b/src/dropdown/demos/enUS/manual-position.demo.vue
@@ -97,6 +97,7 @@ function onClickoutside() {
     :options="options"
     :show="showDropdown"
     :on-clickoutside="onClickoutside"
+    @update:show="(v) => (showDropdown = v)"
     @select="handleSelect"
   />
 </template>

--- a/src/dropdown/demos/zhCN/manual-position.demo.vue
+++ b/src/dropdown/demos/zhCN/manual-position.demo.vue
@@ -97,6 +97,7 @@ function onClickoutside() {
     :options="options"
     :show="showDropdown"
     :on-clickoutside="onClickoutside"
+    @update:show="(v) => (showDropdown = v)"
     @select="handleSelect"
   />
 </template>


### PR DESCRIPTION
# 描述
当前 Dropdown 组件的“手动定位”示例使用了受控模式（`:show`），但是未监听 `update:show` 事件。
这会导致一个交互体验问题：当用户按下 `Esc` 键时，组件内部触发了关闭请求，但由于父组件没有响应并更新 `show` 的值，导致下拉菜单无法关闭。

# 变更
1. **代码示例更新**：在 `manual-position` 的示例代码中增加了 `@update:show` 监听，确保 `Esc` 键能正常关闭菜单。
2. **文档说明更新**：在文档提示中增加了关于 `update:show` 的说明，明确告知开发者在手动定位（受控模式）下需要手动处理关闭逻辑。

# 关联 Issue
Fixes #7383