### PR TITLE
fix(equation): remove `@types/katex` to avoid type conflicts

### DIFF
--- a/CHANGELOG.en-US.md
+++ b/CHANGELOG.en-US.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## NEXT_VERSION
+
+### Fixes
+
+- Fix `n-equation` type conflicts when using katex v0.16.18+, closes [#7423](https://github.com/tusen-ai/naive-ui/issues/7423).
+
 ## 2.43.2
 
 ### Fixes

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## NEXT_VERSION
+
+### Fixes
+
+- 修复 `n-equation` 在使用 katex v0.16.18+ 时出现类型冲突，关闭 [#7423](https://github.com/tusen-ai/naive-ui/issues/7423)
+
 ## 2.43.2
 
 ### Fixes

--- a/package.json
+++ b/package.json
@@ -71,7 +71,6 @@
   "dependencies": {
     "@css-render/plugin-bem": "^0.15.14",
     "@css-render/vue3-ssr": "^0.15.14",
-    "@types/katex": "^0.16.2",
     "@types/lodash": "^4.17.20",
     "@types/lodash-es": "^4.17.12",
     "async-validator": "^4.2.5",
@@ -131,7 +130,7 @@
     "husky": "^9.1.7",
     "inquirer": "^12.7.0",
     "jsdom": "^27.0.0",
-    "katex": "^0.16.22",
+    "katex": "^0.16.27",
     "lint-staged": "^16.1.6",
     "marked": "^12.0.2",
     "prettier": "^3.6.2",


### PR DESCRIPTION
Since katex v0.16.18, katex includes its own TypeScript definitions. Having @types/katex installed causes type conflicts due to incompatible strict option types between the two definitions.
update katex to latest version: v0.16.27

Refs: https://github.com/KaTeX/KaTeX/releases/tag/v0.16.18 close #7423

<!--
!!! Please read the following content if this is your first pull request !!!

1. If you are working on docs, please set `docs` branch as the target branch.
2. If you are working on bug fixes or new features, please set `main` branch as the target branch.

For people who are working on 2, please add changelog to `CHANGELOG.zh-CN.md` & `CHANGELOG.en-US.md` in the PR. You need to add changelog to both files. You can use English in both file. The develop team will translate it later.

About docs & changelog's format and other tips, see in `CONTRIBUTING.md`.
-->
<!--
!!! 如果这是你第一次提交 PR，请阅读下面的内容 !!!

1. 如果你在修改文档，请提交到 `docs` 分支
2. 如果你在修复 Bug 或者开发新的特性，请提交到 `main` 分支

对于进行工作 2 的人，请在 `CHANGELOG.zh-CN.md` & `CHANGELOG.en-US.md` 中添加变更日志，你需要在两个文件中都添加变更日志。你可以只使用中文，开发团队会在之后进行翻译。

关于文档和变更日志的格式以及其他的帮助信息，请参考 `CONTRIBUTING.md`。
-->
