### PR TITLE
Revert "fix(equation): remove `@types/katex` to avoid type conflicts"

### DIFF
--- a/CHANGELOG.en-US.md
+++ b/CHANGELOG.en-US.md
@@ -1,11 +1,5 @@
 # CHANGELOG
 
-## NEXT_VERSION
-
-### Fixes
-
-- Fix `n-equation` type conflicts when using katex v0.16.18+, closes [#7423](https://github.com/tusen-ai/naive-ui/issues/7423).
-
 ## 2.43.2
 
 ### Fixes

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -1,11 +1,5 @@
 # CHANGELOG
 
-## NEXT_VERSION
-
-### Fixes
-
-- 修复 `n-equation` 在使用 katex v0.16.18+ 时出现类型冲突，关闭 [#7423](https://github.com/tusen-ai/naive-ui/issues/7423)
-
 ## 2.43.2
 
 ### Fixes

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
   "dependencies": {
     "@css-render/plugin-bem": "^0.15.14",
     "@css-render/vue3-ssr": "^0.15.14",
+    "@types/katex": "^0.16.2",
     "@types/lodash": "^4.17.20",
     "@types/lodash-es": "^4.17.12",
     "async-validator": "^4.2.5",
@@ -130,7 +131,7 @@
     "husky": "^9.1.7",
     "inquirer": "^12.7.0",
     "jsdom": "^27.0.0",
-    "katex": "^0.16.27",
+    "katex": "^0.16.22",
     "lint-staged": "^16.1.6",
     "marked": "^12.0.2",
     "prettier": "^3.6.2",


### PR DESCRIPTION
Reverts tusen-ai/naive-ui#7432

due to katex types field is not set correctly.

