### PR TITLE
fix: resolve dropdown manual position demo lint error

### DIFF
--- a/src/dropdown/demos/enUS/manual-position.demo.vue
+++ b/src/dropdown/demos/enUS/manual-position.demo.vue
@@ -80,6 +80,10 @@ function onClickoutside() {
   message.info('clickoutside')
   showDropdown.value = false
 }
+
+function handleUpdateShow(show: boolean) {
+  showDropdown.value = show
+}
 </script>
 
 <template>
@@ -97,7 +101,7 @@ function onClickoutside() {
     :options="options"
     :show="showDropdown"
     :on-clickoutside="onClickoutside"
-    @update:show="(v) => (showDropdown = v)"
+    @update:show="handleUpdateShow"
     @select="handleSelect"
   />
 </template>

--- a/src/dropdown/demos/zhCN/manual-position.demo.vue
+++ b/src/dropdown/demos/zhCN/manual-position.demo.vue
@@ -80,6 +80,10 @@ function onClickoutside() {
   message.info('clickoutside')
   showDropdown.value = false
 }
+
+function handleUpdateShow(show: boolean) {
+  showDropdown.value = show
+}
 </script>
 
 <template>
@@ -97,7 +101,7 @@ function onClickoutside() {
     :options="options"
     :show="showDropdown"
     :on-clickoutside="onClickoutside"
-    @update:show="(v) => (showDropdown = v)"
+    @update:show="handleUpdateShow"
     @select="handleSelect"
   />
 </template>


### PR DESCRIPTION
## Summary
- replace inline `@update:show` handlers with typed named handlers in the dropdown manual-position demos
- fix vue-tsc implicit-any errors during demo type checking

## Validation
- pnpm run lint
